### PR TITLE
chore: add Claude Code agents, skills, hooks, and Prettier setup

### DIFF
--- a/.claude/agents/code-quality-checker.md
+++ b/.claude/agents/code-quality-checker.md
@@ -1,0 +1,55 @@
+---
+name: code-quality-checker
+description: Reviews code for readability, performance, maintainability, and adherence to project patterns
+tools: Read, Grep, Glob
+model: haiku
+---
+
+You are a code quality expert reviewing changes in a Next.js + Prisma + Zustand monorepo.
+
+## Process
+
+1. Run `git diff master...HEAD` to see all changes in the current branch
+2. Read each changed file fully for context
+3. Analyze against the checklist below
+
+## Checklist
+
+### Readability
+- Clear, descriptive variable and function names
+- Excessive nesting (more than 3 levels deep)
+- Functions longer than 50 lines that should be split
+- Consistent naming conventions (camelCase for variables, PascalCase for components)
+
+### Performance
+- Unnecessary re-renders (missing useMemo/useCallback where needed)
+- N+1 query patterns in Prisma calls
+- Large bundles (importing entire libraries vs specific modules)
+- Missing loading/error states in async operations
+
+### DRY & Patterns
+- Duplicated code that should be extracted
+- Inconsistency with existing project patterns
+- Shared logic that belongs in `packages/utils`
+- Types that should be in `packages/types`
+
+### Error Handling
+- Unhandled promise rejections
+- Missing try/catch on API routes
+- Generic error messages that don't help debugging
+- Silent failures (empty catch blocks)
+
+### TypeScript
+- Use of `any` type where a proper type exists
+- Missing return types on exported functions
+- Unsafe type assertions (`as unknown as`)
+
+## Output Format
+
+For each finding:
+- **Category**: Readability / Performance / DRY / Error Handling / TypeScript
+- **File**: path:line_number
+- **Issue**: What's wrong
+- **Suggestion**: How to improve it, with code example if helpful
+
+End with a summary of the most impactful improvements.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: security-reviewer
+description: Security expert that reviews code changes for vulnerabilities, secrets, dependency risks, and compliance issues
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a security expert reviewing code changes in a Next.js + Prisma monorepo.
+
+## Process
+
+1. Run `git diff master...HEAD` to see all changes in the current branch
+2. For each changed file, analyze for security issues
+
+## Checklist
+
+### Secrets & Credentials
+- Hardcoded API keys, passwords, tokens, or connection strings
+- `.env` files or secrets committed to git
+- Exposed database URLs or auth secrets
+
+### Injection Vulnerabilities
+- SQL injection (raw queries, string concatenation in Prisma)
+- XSS (unsanitized user input rendered in JSX, `dangerouslySetInnerHTML`)
+- Command injection (unsanitized input in shell commands)
+- Path traversal (user input in file paths)
+
+### Authentication & Authorization
+- Missing auth checks on API routes
+- Weak password handling (plaintext, weak hashing)
+- JWT/session misconfigurations
+- Missing CSRF protection
+- Role bypass (ADMIN checks missing or bypassable)
+
+### Dependencies
+- Known vulnerable packages added
+- Suspicious or unmaintained dependencies
+- Overly permissive version ranges
+
+### Data Handling
+- Sensitive data in URL params or logs
+- Missing input validation on API endpoints
+- Unencrypted sensitive data storage
+- PII exposure in responses
+
+## Output Format
+
+For each issue found:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **File**: path:line_number
+- **Issue**: Brief description
+- **Fix**: Concrete code suggestion
+
+End with a summary: total issues by severity, and an overall risk assessment.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -I {} sh -c 'if [ -f \"{}\" ] && echo \"{}\" | grep -qE \"\\.(ts|tsx|js|jsx|json|css|md)$\"; then npx prettier --write \"{}\" 2>/dev/null; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pr-review
+description: Comprehensive PR review combining security and code quality checks on the current branch
+allowed-tools: Read, Grep, Glob, Bash, Agent
+---
+
+Run a full review of the current branch's changes against master. Execute the following steps:
+
+## Step 1: Gather context
+- Run `git log --oneline master..HEAD` to list all commits in this branch
+- Run `git diff --stat master...HEAD` to see which files changed
+- Run `git diff master...HEAD` to see the full diff
+
+## Step 2: Launch reviews in parallel
+Launch both agents simultaneously:
+1. **@security-reviewer** — analyze all changes for security vulnerabilities
+2. **@code-quality-checker** — analyze all changes for code quality issues
+
+## Step 3: Summarize
+After both agents complete, produce a unified report:
+
+### PR Review Summary
+- **Branch**: (branch name)
+- **Commits**: (count)
+- **Files changed**: (count)
+
+### Security Findings
+(Summary from security-reviewer, grouped by severity)
+
+### Code Quality Findings
+(Summary from code-quality-checker, grouped by category)
+
+### Verdict
+- APPROVE: No critical/high issues found
+- REQUEST CHANGES: Critical or high severity issues that must be fixed
+- COMMENT: Only medium/low issues, suggestions for improvement

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "turbo run lint"
   },
   "devDependencies": {
+    "prettier": "^3.8.1",
     "turbo": "latest"
   },
   "packageManager": "pnpm@10.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     devDependencies:
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
       turbo:
         specifier: latest
-        version: 2.8.20
+        version: 2.8.21
 
   apps/mobile:
     dependencies:
@@ -1640,33 +1643,33 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
-  '@turbo/darwin-64@2.8.20':
-    resolution: {integrity: sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==}
+  '@turbo/darwin-64@2.8.21':
+    resolution: {integrity: sha512-kfGoM0Iw8ZNZpbds+4IzOe0hjvHldqJwUPRAjXJi3KBxg/QOZL95N893SRoMtf2aJ+jJ3dk32yPkp8rvcIjP9g==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.8.20':
-    resolution: {integrity: sha512-Gpyh9ATFGThD6/s9L95YWY54cizg/VRWl2B67h0yofG8BpHf67DFAh9nuJVKG7bY0+SBJDAo5cMur+wOl9YOYw==}
+  '@turbo/darwin-arm64@2.8.21':
+    resolution: {integrity: sha512-o9HEflxUEyr987x0cTUzZBhDOyL6u95JmdmlkH2VyxAw7zq2sdtM5e72y9ufv2N5SIoOBw1fVn9UES5VY5H6vQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.8.20':
-    resolution: {integrity: sha512-p2QxWUYyYUgUFG0b0kR+pPi8t7c9uaVlRtjTTI1AbCvVqkpjUfCcReBn6DgG/Hu8xrWdKLuyQFaLYFzQskZbcA==}
+  '@turbo/linux-64@2.8.21':
+    resolution: {integrity: sha512-uTxlCcXWy5h1fSSymP8XSJ+AudzEHMDV3IDfKX7+DGB8kgJ+SLoTUAH7z4OFA7I/l2sznz0upPdbNNZs91YMag==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.8.20':
-    resolution: {integrity: sha512-Gn5yjlZGLRZWarLWqdQzv0wMqyBNIdq1QLi48F1oY5Lo9kiohuf7BPQWtWxeNVS2NgJ1+nb/DzK1JduYC4AWOA==}
+  '@turbo/linux-arm64@2.8.21':
+    resolution: {integrity: sha512-cdHIcxNcihHHkCHp0Y4Zb60K4Qz+CK4xw1gb6s/t/9o4SMeMj+hTBCtoW6QpPnl9xPYmxuTou8Zw6+cylTnREg==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.8.20':
-    resolution: {integrity: sha512-vyaDpYk/8T6Qz5V/X+ihKvKFEZFUoC0oxYpC1sZanK6gaESJlmV3cMRT3Qhcg4D2VxvtC2Jjs9IRkrZGL+exLw==}
+  '@turbo/windows-64@2.8.21':
+    resolution: {integrity: sha512-/iBj4OzbqEY8CX+eaeKbBTMZv2CLXNrt0692F7HnK7LcyYwyDecaAiSET6ZzL4opT7sbwkKvzAC/fhqT3Quu1A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.8.20':
-    resolution: {integrity: sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw==}
+  '@turbo/windows-arm64@2.8.21':
+    resolution: {integrity: sha512-95tMA/ZbIidJFUUtkmqioQ1gf3n3I1YbRP3ZgVdWTVn2qVbkodcIdGXBKRHHrIbRsLRl99SiHi/L7IxhpZDagQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -1897,6 +1900,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4035,6 +4039,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -4677,8 +4686,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo@2.8.20:
-    resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
+  turbo@2.8.21:
+    resolution: {integrity: sha512-FlJ8OD5Qcp0jTAM7E4a/RhUzRNds2GzKlyxHKA6N247VLy628rrxAGlMpIXSz6VB430+TiQDJ/SMl6PL1lu6wQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -6733,22 +6742,22 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@turbo/darwin-64@2.8.20':
+  '@turbo/darwin-64@2.8.21':
     optional: true
 
-  '@turbo/darwin-arm64@2.8.20':
+  '@turbo/darwin-arm64@2.8.21':
     optional: true
 
-  '@turbo/linux-64@2.8.20':
+  '@turbo/linux-64@2.8.21':
     optional: true
 
-  '@turbo/linux-arm64@2.8.20':
+  '@turbo/linux-arm64@2.8.21':
     optional: true
 
-  '@turbo/windows-64@2.8.20':
+  '@turbo/windows-64@2.8.21':
     optional: true
 
-  '@turbo/windows-arm64@2.8.20':
+  '@turbo/windows-arm64@2.8.21':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -9584,6 +9593,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@3.8.1: {}
+
   pretty-bytes@5.6.0: {}
 
   pretty-format@29.7.0:
@@ -10334,14 +10345,14 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  turbo@2.8.20:
+  turbo@2.8.21:
     optionalDependencies:
-      '@turbo/darwin-64': 2.8.20
-      '@turbo/darwin-arm64': 2.8.20
-      '@turbo/linux-64': 2.8.20
-      '@turbo/linux-arm64': 2.8.20
-      '@turbo/windows-64': 2.8.20
-      '@turbo/windows-arm64': 2.8.20
+      '@turbo/darwin-64': 2.8.21
+      '@turbo/darwin-arm64': 2.8.21
+      '@turbo/linux-64': 2.8.21
+      '@turbo/linux-arm64': 2.8.21
+      '@turbo/windows-64': 2.8.21
+      '@turbo/windows-arm64': 2.8.21
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add `.claude/agents/` with `security-reviewer` and `code-quality-checker` subagents for automated PR reviews
- Add `.claude/skills/pr-review/` skill that runs both agents in parallel and produces a unified report
- Add `.claude/settings.json` with a `PostToolUse` hook that auto-formats files with Prettier after edits
- Add `.prettierrc` config and `prettier` dev dependency

## Test plan
- [ ] Trigger `/pr-review` skill on a branch with changes and verify both agents run and produce a report
- [ ] Edit a `.ts`/`.tsx` file and verify Prettier auto-formats it via the hook
- [ ] Confirm `.prettierrc` rules apply (single quotes, no semi, trailing comma, 120 print width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)