### PR TITLE
feat: create db backup

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+BACKUP_DIR="$HOME/.fulbito-backups"
+MAX_BACKUPS=4
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_FILE="$BACKUP_DIR/fulbito_$TIMESTAMP.sql.gz"
+
+# Load DATABASE_URL from backend .env if not already set
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../apps/backend/.env"
+
+if [[ -z "${DATABASE_URL:-}" && -f "$ENV_FILE" ]]; then
+  export $(grep -E '^DATABASE_URL=' "$ENV_FILE" | xargs)
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "❌  DATABASE_URL is not set. Add it to apps/backend/.env or export it before running this script."
+  exit 1
+fi
+
+# ── pg_dump lookup ────────────────────────────────────────────────────────────
+PG_DUMP=""
+for candidate in \
+  "$(which pg_dump 2>/dev/null)" \
+  "/opt/homebrew/bin/pg_dump" \
+  "/usr/local/bin/pg_dump" \
+  "/usr/bin/pg_dump" \
+  "/Applications/Postgres.app/Contents/Versions/latest/bin/pg_dump"
+do
+  if [[ -x "$candidate" ]]; then
+    PG_DUMP="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$PG_DUMP" ]]; then
+  echo "❌  pg_dump not found. Install it with:"
+  echo "    brew install libpq && brew link --force libpq"
+  exit 1
+fi
+
+# ── Backup ────────────────────────────────────────────────────────────────────
+mkdir -p "$BACKUP_DIR"
+
+echo "🗄️  Starting backup → $BACKUP_FILE"
+"$PG_DUMP" "$DATABASE_URL" --no-owner --no-acl | gzip > "$BACKUP_FILE"
+echo "✅  Backup complete ($(du -sh "$BACKUP_FILE" | cut -f1))"
+
+# ── Rotate: keep only last MAX_BACKUPS ────────────────────────────────────────
+mapfile -t OLD_BACKUPS < <(ls -t "$BACKUP_DIR"/fulbito_*.sql.gz 2>/dev/null | tail -n +$((MAX_BACKUPS + 1)))
+
+if [[ ${#OLD_BACKUPS[@]} -gt 0 ]]; then
+  echo "🗑️  Removing ${#OLD_BACKUPS[@]} old backup(s):"
+  for f in "${OLD_BACKUPS[@]}"; do
+    echo "    - $(basename "$f")"
+    rm -f "$f"
+  done
+fi
+
+echo "📦  Backups kept: $(ls "$BACKUP_DIR"/fulbito_*.sql.gz 2>/dev/null | wc -l | tr -d ' ')/$MAX_BACKUPS"


### PR DESCRIPTION
<p data-start="152" data-end="391">Adds <code data-start="157" data-end="179">scripts/backup-db.sh</code> to automate backups of the Fulbito backend database using <code data-start="238" data-end="247">pg_dump</code>.<br data-start="248" data-end="251">
Backups are compressed with <code data-start="279" data-end="285">gzip</code>, stored locally, and rotated to keep only the four most recent files, preventing uncontrolled disk usage.</p>
<hr data-start="393" data-end="396">
<h2 data-section-id="1b8n19b" data-start="398" data-end="412">⚙️ Behavior</h2>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
Area | Details
-- | --
Connection | Uses DATABASE_URL from the environment; if not set, loads it from apps/backend/.env.
Dump | Executes pg_dump "$DATABASE_URL" --no-owner --no-acl to generate a portable dump (avoids role/permission issues).
Output | Creates files named fulbito_YYYYMMDD_HHMMSS.sql.gz in ~/.fulbito-backups.
pg_dump resolution | Locates pg_dump via PATH, Homebrew (/opt/homebrew, /usr/local), system paths, or Postgres.app.
Rotation | After each run, removes older fulbito_*.sql.gz files, keeping a maximum of 4 backups.

</div></div>
<hr data-start="1027" data-end="1030">
<h2 data-section-id="hko51u" data-start="1032" data-end="1050">📦 Requirements</h2>
<ul data-start="1052" data-end="1287">
<li data-section-id="qu0a5j" data-start="1052" data-end="1152">
<code data-start="1054" data-end="1068">DATABASE_URL</code> must be:
<ul data-start="1080" data-end="1152">
<li data-section-id="1mllv13" data-start="1080" data-end="1117">
exported in the environment, <strong data-start="1111" data-end="1117">or</strong>
</li>
<li data-section-id="6r6bt7" data-start="1120" data-end="1152">
defined in <code data-start="1133" data-end="1152">apps/backend/.env</code>
</li>
</ul>
</li>
<li data-section-id="1eqbidy" data-start="1153" data-end="1287">
<p data-start="1155" data-end="1223">PostgreSQL client tools installed (<code data-start="1190" data-end="1199">pg_dump</code> available)<br data-start="1210" data-end="1213">
Example:</p>
<pre class="overflow-visible! px-0!" data-start="1226" data-end="1287"><div class="relative w-full mt-4 mb-1"><div class=""><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class="relative"><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼk ͼy"><div class="cm-scroller"><pre class="cm-content q9tKkq_readonly m-0"><code><span>brew install libpq &amp;&amp; brew link </span><span class="ͼu">--force</span><span> libpq</span></code></pre></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></pre>
</li>
</ul>
<hr data-start="1289" data-end="1292">
<h2 data-section-id="1lua358" data-start="1294" data-end="1311">🧪 How to test</h2>
<ol data-start="1313" data-end="1644">
<li data-section-id="16wkjf6" data-start="1313" data-end="1350">
Ensure <code data-start="1323" data-end="1337">DATABASE_URL</code> is available
</li>
<li data-section-id="mcvcxn" data-start="1351" data-end="1460">
<p data-start="1354" data-end="1369">From repo root:</p>
<pre class="overflow-visible! px-0!" data-start="1373" data-end="1460"><div class="relative w-full mt-4 mb-1"><div class=""><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class="relative"><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼk ͼy"><div class="cm-scroller"><pre class="cm-content q9tKkq_readonly m-0"><code><span class="ͼs">chmod</span><span> </span><span class="ͼn">+</span><span>x scripts/backup-db.sh   </span><span class="ͼl"># if needed</span><br><span>./scripts/backup-db.sh</span></code></pre></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></pre>
</li>
<li data-section-id="qb4t5s" data-start="1461" data-end="1644">
Validate:
<ul data-start="1477" data-end="1644">
<li data-section-id="1nue8nm" data-start="1477" data-end="1537">
A new <code data-start="1485" data-end="1494">.sql.gz</code> file is created under <code data-start="1517" data-end="1537">~/.fulbito-backups</code>
</li>
<li data-section-id="12u9x8g" data-start="1541" data-end="1570">
File size is greater than 0
</li>
<li data-section-id="1wbij4p" data-start="1574" data-end="1644">
If more than 4 backups exist, older ones are removed (only 4 remain)
</li>
</ul>
</li>
</ol>
<hr data-start="1646" data-end="1649">
<h2 data-section-id="ghihqo" data-start="1651" data-end="1660">🎯 Why</h2>
<ul data-start="1662" data-end="1881">
<li data-section-id="7d9p90" data-start="1662" data-end="1726">
Reduces risk of data loss with a consistent backup mechanism
</li>
<li data-section-id="1hk0hf8" data-start="1727" data-end="1761">
Eliminates manual backup steps
</li>
<li data-section-id="162vlw8" data-start="1762" data-end="1816">
Keeps storage usage bounded via automatic rotation
</li>
<li data-section-id="n1jwdx" data-start="1817" data-end="1881">
Lightweight and easy to integrate with cron or any scheduler
</li>
</ul>
