### PR TITLE
feat(mvp): add Match MVP selection on history (web)

### DIFF
--- a/apps/backend/prisma/migrations/20260512105249_add_match_mvp/migration.sql
+++ b/apps/backend/prisma/migrations/20260512105249_add_match_mvp/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Match" ADD COLUMN     "mvpId" TEXT;
+
+-- AlterTable
+ALTER TABLE "Player" ADD COLUMN     "mvpCount" INTEGER NOT NULL DEFAULT 0;
+
+-- AddForeignKey
+ALTER TABLE "Match" ADD CONSTRAINT "Match_mvpId_fkey" FOREIGN KEY ("mvpId") REFERENCES "Player"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -17,7 +17,9 @@ model Player {
   updatedAt        DateTime      @updatedAt
   photoUrl         String?
   shirtDutiesCount Int           @default(0)
+  mvpCount         Int           @default(0)
   shirtMatches     Match[]       @relation("ShirtDutyMatches")
+  mvpMatches       Match[]       @relation("MatchMVP")
   matchPlayers     MatchPlayer[]
 }
 
@@ -32,6 +34,8 @@ model Match {
   updatedAt           DateTime      @updatedAt
   shirtsResponsibleId String?
   shirtsResponsible   Player?       @relation("ShirtDutyMatches", fields: [shirtsResponsibleId], references: [id])
+  mvpId               String?
+  mvp                 Player?       @relation("MatchMVP", fields: [mvpId], references: [id], onDelete: SetNull)
   players             MatchPlayer[]
 }
 

--- a/apps/backend/src/app/api/matches/[id]/route.ts
+++ b/apps/backend/src/app/api/matches/[id]/route.ts
@@ -8,7 +8,27 @@ export async function DELETE(_req: Request, context: unknown) {
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status })
   try {
     const { id } = (context as { params: { id: string } }).params
-    await prisma.match.delete({ where: { id } })
+    const current = await prisma.match.findUnique({
+      where: { id },
+      select: { shirtsResponsibleId: true, mvpId: true }
+    })
+    if (!current) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    await prisma.$transaction([
+      ...(current.shirtsResponsibleId ? [
+        prisma.player.update({
+          where: { id: current.shirtsResponsibleId },
+          data: { shirtDutiesCount: { decrement: 1 } }
+        })
+      ] : []),
+      ...(current.mvpId ? [
+        prisma.player.update({
+          where: { id: current.mvpId },
+          data: { mvpCount: { decrement: 1 } }
+        })
+      ] : []),
+      prisma.match.delete({ where: { id } })
+    ])
     return NextResponse.json({ ok: true })
   } catch (err) {
     return NextResponse.json({ error: `Failed to delete match: ${err}` }, { status: 500 })
@@ -34,6 +54,7 @@ export async function GET(_req: Request, context: unknown) {
       type: m.type,
       name: m.name ?? undefined,
       shirtsResponsibleId: (m as unknown as { shirtsResponsibleId?: string | null }).shirtsResponsibleId ?? undefined,
+      mvpId: (m as unknown as { mvpId?: string | null }).mvpId ?? undefined,
       teamAScore: m.teamAScore,
       teamBScore: m.teamBScore,
       teamA: m.players
@@ -57,20 +78,46 @@ export async function PUT(req: Request, context: unknown) {
     const b = await req.json()
     const { id } = (context as { params: { id: string } }).params
 
-    // Update basic fields
-    const data: { date?: Date, type?: string, name?: string | null, teamAScore?: number, teamBScore?: number, shirtsResponsibleId?: string | null } = {}
+    const data: { date?: Date, type?: string, name?: string | null, teamAScore?: number, teamBScore?: number, shirtsResponsibleId?: string | null, mvpId?: string | null } = {}
     if (b.date) data.date = new Date(`${b.date}T00:00:00.000Z`)
     if (typeof b.type === 'string') data.type = b.type
     if (typeof b.name === 'string' || b.name === null) data.name = b.name ?? null
     if (typeof b.teamAScore === 'number') data.teamAScore = b.teamAScore
     if (typeof b.teamBScore === 'number') data.teamBScore = b.teamBScore
     if ('shirtsResponsibleId' in b) data.shirtsResponsibleId = b.shirtsResponsibleId ?? null
+    if ('mvpId' in b) data.mvpId = b.mvpId ?? null
 
-    const current = await prisma.match.findUnique({ where: { id }, select: { shirtsResponsibleId: true } })
-    const oldId = current?.shirtsResponsibleId ?? null
-    const newId = ('shirtsResponsibleId' in b) ? (b.shirtsResponsibleId ?? null) : oldId
+    const current = await prisma.match.findUnique({
+      where: { id },
+      select: { shirtsResponsibleId: true, mvpId: true, players: { select: { playerId: true } } }
+    })
+    if (!current) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-    // If teams provided, replace participants atomically
+    const oldShirtId = current.shirtsResponsibleId ?? null
+    const newShirtId = ('shirtsResponsibleId' in b) ? (b.shirtsResponsibleId ?? null) : oldShirtId
+    const oldMvpId = current.mvpId ?? null
+    const newMvpId = ('mvpId' in b) ? (b.mvpId ?? null) : oldMvpId
+
+    if (newMvpId) {
+      const teamsProvided = Array.isArray(b.teamA) || Array.isArray(b.teamB)
+      const participants = teamsProvided
+        ? new Set<string>([...(b.teamA || []), ...(b.teamB || [])].map((p: { id: string }) => p.id))
+        : new Set<string>(current.players.map(p => p.playerId))
+      if (!participants.has(newMvpId)) {
+        return NextResponse.json({ error: 'MVP must be a player in this match' }, { status: 400 })
+      }
+    }
+
+    const shirtOps = newShirtId !== oldShirtId ? [
+      ...(oldShirtId ? [prisma.player.update({ where: { id: oldShirtId }, data: { shirtDutiesCount: { decrement: 1 } } })] : []),
+      ...(newShirtId ? [prisma.player.update({ where: { id: newShirtId }, data: { shirtDutiesCount: { increment: 1 } } })] : [])
+    ] : []
+
+    const mvpOps = newMvpId !== oldMvpId ? [
+      ...(oldMvpId ? [prisma.player.update({ where: { id: oldMvpId }, data: { mvpCount: { decrement: 1 } } })] : []),
+      ...(newMvpId ? [prisma.player.update({ where: { id: newMvpId }, data: { mvpCount: { increment: 1 } } })] : [])
+    ] : []
+
     if (Array.isArray(b.teamA) || Array.isArray(b.teamB)) {
       await prisma.$transaction([
         prisma.match.update({ where: { id }, data }),
@@ -81,18 +128,14 @@ export async function PUT(req: Request, context: unknown) {
             ...((b.teamB || []).map((p: { id: string, goals: number, performance: number }) => ({ matchId: id, playerId: p.id, team: 'B', goals: p.goals ?? 0, performance: p.performance ?? 5 })))
           ]
         }),
-        ...(newId !== oldId ? [
-          ...(oldId ? [prisma.player.update({ where: { id: oldId }, data: { shirtDutiesCount: { decrement: 1 } } })] : []),
-          ...(newId ? [prisma.player.update({ where: { id: newId }, data: { shirtDutiesCount: { increment: 1 } } })] : [])
-        ] : [])
+        ...shirtOps,
+        ...mvpOps
       ])
     } else {
       await prisma.$transaction([
         prisma.match.update({ where: { id }, data }),
-        ...(newId !== oldId ? [
-          ...(oldId ? [prisma.player.update({ where: { id: oldId }, data: { shirtDutiesCount: { decrement: 1 } } })] : []),
-          ...(newId ? [prisma.player.update({ where: { id: newId }, data: { shirtDutiesCount: { increment: 1 } } })] : [])
-        ] : [])
+        ...shirtOps,
+        ...mvpOps
       ])
     }
 
@@ -101,4 +144,3 @@ export async function PUT(req: Request, context: unknown) {
     return NextResponse.json({ error: `Failed to update match ${err}` }, { status: 500 })
   }
 }
-

--- a/apps/backend/src/app/api/matches/route.ts
+++ b/apps/backend/src/app/api/matches/route.ts
@@ -14,6 +14,7 @@ type IncomingMatchBody = {
   teamA?: IncomingMatchPlayer[]
   teamB?: IncomingMatchPlayer[]
   shirtsResponsibleId?: string | null
+  mvpId?: string | null
 }
 
 export async function GET() {
@@ -29,6 +30,14 @@ export async function POST(req: Request) {
   const gate = await requireAdmin()
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status })
   const b = (await req.json()) as IncomingMatchBody
+
+  if (b.mvpId) {
+    const participants = new Set([...(b.teamA || []), ...(b.teamB || [])].map(p => p.id))
+    if (!participants.has(b.mvpId)) {
+      return NextResponse.json({ error: 'MVP must be a player in this match' }, { status: 400 })
+    }
+  }
+
   const [created] = await prisma.$transaction([
     prisma.match.create({
       data: {
@@ -38,6 +47,7 @@ export async function POST(req: Request) {
         teamAScore: b.teamAScore,
         teamBScore: b.teamBScore,
         shirtsResponsibleId: b.shirtsResponsibleId ?? null,
+        mvpId: b.mvpId ?? null,
         players: {
           create: [
             ...(b.teamA || []).map((p: IncomingMatchPlayer) => ({ playerId: p.id, team: 'A' as const, goals: p.goals, performance: p.performance })),
@@ -50,6 +60,12 @@ export async function POST(req: Request) {
       prisma.player.update({
         where: { id: b.shirtsResponsibleId },
         data: { shirtDutiesCount: { increment: 1 } }
+      })
+    ] : []),
+    ...(b.mvpId ? [
+      prisma.player.update({
+        where: { id: b.mvpId },
+        data: { mvpCount: { increment: 1 } }
       })
     ] : [])
   ])

--- a/apps/backend/src/lib/shape.ts
+++ b/apps/backend/src/lib/shape.ts
@@ -9,6 +9,7 @@ export function shapeStoreMatches(
     teamAScore: number
     teamBScore: number
     shirtsResponsibleId?: string | null
+    mvpId?: string | null
     players: Array<{ playerId: string; team: 'A' | 'B'; goals: number; performance: number }>
   }>,
   nameMap: Map<string, string>
@@ -19,6 +20,7 @@ export function shapeStoreMatches(
     type: m.type,
     name: m.name ?? undefined,
     shirtsResponsibleId: m.shirtsResponsibleId ?? undefined,
+    mvpId: m.mvpId ?? undefined,
     teamAScore: m.teamAScore,
     teamBScore: m.teamBScore,
     teamA: m.players

--- a/apps/web/src/app/history/historyClient.tsx
+++ b/apps/web/src/app/history/historyClient.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { useSession } from "next-auth/react";
-import { TrophyIcon } from "@heroicons/react/24/solid";
 import type { Match, Player } from "@fulbito/types";
 import { useMatchStore } from "@/store/useMatchStore";
 import {
@@ -32,7 +31,6 @@ export default function HistoryClient({
     hydrateMatches,
     addMatch,
     updateMatch,
-    setMvp,
     deleteMatch,
     matches: storeMatches,
   } = useMatchStore();
@@ -42,7 +40,6 @@ export default function HistoryClient({
   >(false);
   const [showModal, setShowModal] = useState(false);
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
-  const [mvpModalMatch, setMvpModalMatch] = useState<Match | null>(null);
 
   const [fromDate, setFromDate] = useState<string>("");
   const [toDate, setToDate] = useState<string>("");
@@ -180,10 +177,15 @@ export default function HistoryClient({
                     {m.teamA.map((p: Match["teamA"][number]) => (
                       <div
                         key={p.id}
-                        className="flex justify-between border-b last:border-b-0 py-1"
+                        className="flex justify-between items-center border-b last:border-b-0 py-1"
                       >
                         <span>{p.name}</span>
-                        <span>
+                        <span className="flex items-center gap-1.5">
+                          {m.mvpId === p.id && (
+                            <span aria-label="MVP" role="img">
+                              🏆
+                            </span>
+                          )}
                           {p.goals}⚽ {p.performance}★
                         </span>
                       </div>
@@ -197,10 +199,15 @@ export default function HistoryClient({
                     {m.teamB.map((p: Match["teamB"][number]) => (
                       <div
                         key={p.id}
-                        className="flex justify-between border-b last:border-b-0 py-1"
+                        className="flex justify-between items-center border-b last:border-b-0 py-1"
                       >
                         <span>{p.name}</span>
-                        <span>
+                        <span className="flex items-center gap-1.5">
+                          {m.mvpId === p.id && (
+                            <span aria-label="MVP" role="img">
+                              🏆
+                            </span>
+                          )}
                           {p.goals}⚽ {p.performance}★
                         </span>
                       </div>
@@ -219,12 +226,6 @@ export default function HistoryClient({
                         </span>
                       </div>
                     )}
-                    <MvpBadge
-                      match={m}
-                      players={storePlayers}
-                      isAdmin={isAdmin}
-                      onEdit={() => setMvpModalMatch(m)}
-                    />
                   </div>
                   <div className="flex justify-end gap-3">
                     {isAdmin && (
@@ -249,17 +250,6 @@ export default function HistoryClient({
             ))
         )}
       </div>
-      {mvpModalMatch && (
-        <MvpModal
-          match={mvpModalMatch}
-          players={storePlayers}
-          onClose={() => setMvpModalMatch(null)}
-          onSave={async (mvpId) => {
-            await setMvp(mvpModalMatch.id, mvpId);
-            setMvpModalMatch(null);
-          }}
-        />
-      )}
       <dialog
         open={showModal}
         className="rounded-xl p-0 border-none shadow-2xl w-full h-full fixed inset-0 bg-black/40"
@@ -767,7 +757,7 @@ function RecordModal({
           <div className="flex items-center justify-between gap-3">
             <div className="text-sm">
               <div className="font-semibold flex items-center gap-1.5">
-                <TrophyIcon className="h-4 w-4 text-[var(--color-accent)]" />
+                <span aria-hidden="true">🏆</span>
                 MVP del partido
               </div>
               <div className="text-gray-800">
@@ -841,224 +831,3 @@ function RecordModal({
   );
 }
 
-function MvpBadge({
-  match,
-  players,
-  isAdmin,
-  onEdit,
-}: {
-  match: Match;
-  players: Player[];
-  isAdmin: boolean;
-  onEdit: () => void;
-}) {
-  const mvp = match.mvpId
-    ? players.find((p) => p.id === match.mvpId)
-    : undefined;
-
-  if (!match.mvpId) {
-    if (!isAdmin) {
-      return (
-        <div className="flex items-center gap-1.5 text-gray-400 text-sm">
-          <TrophyIcon className="h-4 w-4" aria-hidden="true" />
-          <span>MVP no registrado</span>
-        </div>
-      );
-    }
-    return (
-      <button
-        type="button"
-        onClick={onEdit}
-        className="inline-flex items-center gap-1.5 text-sm px-2.5 py-1 rounded-full border border-dashed border-gray-300 text-gray-600 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] hover:bg-orange-50 transition"
-        aria-label="Asignar MVP a este partido"
-      >
-        <TrophyIcon className="h-4 w-4" aria-hidden="true" />
-        Asignar MVP
-      </button>
-    );
-  }
-
-  return (
-    <div className="inline-flex items-center gap-1.5 text-sm px-2.5 py-1 rounded-full bg-orange-50 border border-orange-200 text-orange-900">
-      <TrophyIcon
-        className="h-4 w-4 text-[var(--color-accent)]"
-        aria-hidden="true"
-      />
-      <span>
-        MVP: <span className="font-semibold">{mvp?.name ?? "—"}</span>
-      </span>
-      {isAdmin && (
-        <button
-          type="button"
-          onClick={onEdit}
-          className="ml-1 text-xs text-orange-700 hover:text-orange-900 underline"
-          aria-label={`Cambiar MVP de ${mvp?.name ?? "este partido"}`}
-        >
-          cambiar
-        </button>
-      )}
-    </div>
-  );
-}
-
-function MvpModal({
-  match,
-  players,
-  onClose,
-  onSave,
-}: {
-  match: Match;
-  players: Player[];
-  onClose: () => void;
-  onSave: (mvpId: string | null) => Promise<void>;
-}) {
-  const participants = useMemo(() => {
-    return [...match.teamA, ...match.teamB];
-  }, [match]);
-
-  const suggestedId = useMemo(() => {
-    const sorted = [...participants].sort(
-      (a, b) => b.performance - a.performance,
-    );
-    return sorted[0]?.id ?? null;
-  }, [participants]);
-
-  const [selectedId, setSelectedId] = useState<string | null>(
-    match.mvpId ?? suggestedId,
-  );
-  const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSave = async () => {
-    setIsSaving(true);
-    setError(null);
-    try {
-      await onSave(selectedId);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "No se pudo guardar el MVP",
-      );
-      setIsSaving(false);
-    }
-  };
-
-  return (
-    <div
-      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center px-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="mvp-modal-title"
-    >
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-md max-h-[85vh] overflow-y-auto">
-        <div className="flex items-center justify-between px-5 py-4 border-b">
-          <div className="flex items-center gap-2">
-            <TrophyIcon
-              className="h-5 w-5 text-[var(--color-accent)]"
-              aria-hidden="true"
-            />
-            <h2 id="mvp-modal-title" className="text-lg font-semibold">
-              Elegir MVP del partido
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-800"
-            aria-label="Cerrar"
-          >
-            ✕
-          </button>
-        </div>
-
-        <div className="p-5">
-          <p className="text-sm text-gray-600 mb-4">
-            Seleccioná al jugador más destacado del partido. Se sugiere el de
-            mayor performance.
-          </p>
-
-          <ul className="space-y-2" role="radiogroup" aria-label="Jugadores del partido">
-            {participants.map((p) => {
-              const isSelected = selectedId === p.id;
-              const isSuggested = p.id === suggestedId;
-              return (
-                <li key={p.id}>
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={isSelected}
-                    onClick={() => setSelectedId(p.id)}
-                    className={`w-full text-left flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg border transition ${
-                      isSelected
-                        ? "border-[var(--color-brand)] bg-purple-50 ring-1 ring-[var(--color-brand)]"
-                        : "border-gray-200 hover:bg-gray-50"
-                    }`}
-                  >
-                    <div className="flex items-center gap-3 min-w-0">
-                      <span
-                        className={`h-4 w-4 rounded-full border-2 flex-shrink-0 ${
-                          isSelected
-                            ? "border-[var(--color-brand)] bg-[var(--color-brand)]"
-                            : "border-gray-300"
-                        }`}
-                        aria-hidden="true"
-                      />
-                      <div className="min-w-0">
-                        <div className="font-medium truncate">{p.name}</div>
-                        <div className="text-xs text-gray-500">
-                          ⚽ {p.goals} · ★ {p.performance}
-                        </div>
-                      </div>
-                    </div>
-                    {isSuggested && (
-                      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-[var(--color-brand)] text-white flex-shrink-0">
-                        sugerido
-                      </span>
-                    )}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-
-          {error && (
-            <div
-              role="alert"
-              className="mt-4 text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2"
-            >
-              {error}
-            </div>
-          )}
-        </div>
-
-        <div className="flex items-center justify-between gap-3 px-5 py-4 border-t bg-gray-50 rounded-b-xl">
-          <button
-            type="button"
-            onClick={() => onSave(null).then(onClose).catch(() => {})}
-            disabled={isSaving || !match.mvpId}
-            className="text-sm text-gray-600 hover:text-red-700 disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            Quitar MVP
-          </button>
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 rounded-lg border border-gray-300 hover:bg-gray-100 transition"
-            >
-              Cancelar
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={isSaving || !selectedId}
-              aria-busy={isSaving}
-              className="px-4 py-2 rounded-lg bg-[var(--color-brand)] text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition"
-            >
-              {isSaving ? "Guardando..." : "Guardar MVP"}
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/apps/web/src/app/history/historyClient.tsx
+++ b/apps/web/src/app/history/historyClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { useSession } from "next-auth/react";
+import { TrophyIcon } from "@heroicons/react/24/solid";
 import type { Match, Player } from "@fulbito/types";
 import { useMatchStore } from "@/store/useMatchStore";
 import {
@@ -31,6 +32,7 @@ export default function HistoryClient({
     hydrateMatches,
     addMatch,
     updateMatch,
+    setMvp,
     deleteMatch,
     matches: storeMatches,
   } = useMatchStore();
@@ -40,6 +42,7 @@ export default function HistoryClient({
   >(false);
   const [showModal, setShowModal] = useState(false);
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
+  const [mvpModalMatch, setMvpModalMatch] = useState<Match | null>(null);
 
   const [fromDate, setFromDate] = useState<string>("");
   const [toDate, setToDate] = useState<string>("");
@@ -204,37 +207,59 @@ export default function HistoryClient({
                     ))}
                   </div>
                 </div>
-                {m.shirtsResponsibleId && (
-                  <div className="text-sm text-gray-700 mt-2">
-                    Camisetas:{" "}
-                    <span className="font-medium">
-                      {storePlayers.find((p) => p.id === m.shirtsResponsibleId)
-                        ?.name ?? "—"}
-                    </span>
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                    {m.shirtsResponsibleId && (
+                      <div className="text-gray-700">
+                        🎽 Camisetas:{" "}
+                        <span className="font-medium">
+                          {storePlayers.find(
+                            (p) => p.id === m.shirtsResponsibleId,
+                          )?.name ?? "—"}
+                        </span>
+                      </div>
+                    )}
+                    <MvpBadge
+                      match={m}
+                      players={storePlayers}
+                      isAdmin={isAdmin}
+                      onEdit={() => setMvpModalMatch(m)}
+                    />
                   </div>
-                )}
-                <div className="text-right mt-3 flex justify-end gap-3">
-                  {isAdmin && (
-                    <>
-                      <button
-                        className="text-sm px-3 py-1 rounded border hover:bg-gray-50"
-                        onClick={() => setOpen({ mode: "edit", match: m })}
-                      >
-                        Editar
-                      </button>
-                      <button
-                        className="text-red-600 hover:text-red-800 text-sm"
-                        onClick={() => handleDelete(m.id)}
-                      >
-                        Eliminar
-                      </button>
-                    </>
-                  )}
+                  <div className="flex justify-end gap-3">
+                    {isAdmin && (
+                      <>
+                        <button
+                          className="text-sm px-3 py-1 rounded border hover:bg-gray-50"
+                          onClick={() => setOpen({ mode: "edit", match: m })}
+                        >
+                          Editar
+                        </button>
+                        <button
+                          className="text-red-600 hover:text-red-800 text-sm"
+                          onClick={() => handleDelete(m.id)}
+                        >
+                          Eliminar
+                        </button>
+                      </>
+                    )}
+                  </div>
                 </div>
               </div>
             ))
         )}
       </div>
+      {mvpModalMatch && (
+        <MvpModal
+          match={mvpModalMatch}
+          players={storePlayers}
+          onClose={() => setMvpModalMatch(null)}
+          onSave={async (mvpId) => {
+            await setMvp(mvpModalMatch.id, mvpId);
+            setMvpModalMatch(null);
+          }}
+        />
+      )}
       <dialog
         open={showModal}
         className="rounded-xl p-0 border-none shadow-2xl w-full h-full fixed inset-0 bg-black/40"
@@ -340,6 +365,13 @@ function RecordModal({
   const [shirtsResponsibleId, setShirtsResponsibleId] = useState<string | null>(
     initial?.shirtsResponsibleId ?? null,
   );
+  const [mvpId, setMvpId] = useState<string | null>(initial?.mvpId ?? null);
+
+  useEffect(() => {
+    if (!mvpId) return;
+    const inTeams = [...teamA, ...teamB].some((p) => p.id === mvpId);
+    if (!inTeams) setMvpId(null);
+  }, [teamA, teamB, mvpId]);
 
   const [goalsA, setGoalsA] = useState<Record<string, number>>(() =>
     Object.fromEntries(
@@ -456,7 +488,7 @@ function RecordModal({
         name: matchName.trim() || undefined,
       };
 
-      await onSave({ ...m, shirtsResponsibleId: chosen });
+      await onSave({ ...m, shirtsResponsibleId: chosen, mvpId });
 
       alert("Partido guardado correctamente!");
       onClose();
@@ -731,6 +763,54 @@ function RecordModal({
           </div>
         </div>
 
+        <div className="mt-3 bg-amber-50 border border-amber-200 rounded p-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm">
+              <div className="font-semibold flex items-center gap-1.5">
+                <TrophyIcon className="h-4 w-4 text-[var(--color-accent)]" />
+                MVP del partido
+              </div>
+              <div className="text-gray-800">
+                {mvpId
+                  ? (players.find((p) => p.id === mvpId)?.name ?? "—")
+                  : "Opcional — elegí al jugador del partido"}
+              </div>
+            </div>
+            <div className="flex-1">
+              <select
+                className="border rounded px-3 py-2 w-full bg-white"
+                value={mvpId ?? ""}
+                onChange={(e) => setMvpId(e.target.value || null)}
+              >
+                <option value="">Sin MVP</option>
+                {(() => {
+                  const current = [...teamA, ...teamB];
+                  const topPerfId = (() => {
+                    const all = [
+                      ...current.map((p) => ({
+                        id: p.id,
+                        perf: perfA[p.id] ?? perfB[p.id] ?? 0,
+                      })),
+                    ];
+                    return all.sort((a, b) => b.perf - a.perf)[0]?.id;
+                  })();
+                  return current.map((p) => {
+                    const perf = perfA[p.id] ?? perfB[p.id] ?? 0;
+                    const goals = goalsA[p.id] ?? goalsB[p.id] ?? 0;
+                    const isSuggested = p.id === topPerfId && perf > 0;
+                    return (
+                      <option key={p.id} value={p.id}>
+                        {p.name} — ⚽ {goals} · ★ {perf}
+                        {isSuggested ? " · sugerido" : ""}
+                      </option>
+                    );
+                  });
+                })()}
+              </select>
+            </div>
+          </div>
+        </div>
+
         <div className="flex justify-end gap-3 mt-6">
           <button
             className="border px-4 py-2 rounded hover:bg-gray-50"
@@ -755,6 +835,228 @@ function RecordModal({
                 ? "Actualizar Partido"
                 : "Guardar Partido"}
           </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MvpBadge({
+  match,
+  players,
+  isAdmin,
+  onEdit,
+}: {
+  match: Match;
+  players: Player[];
+  isAdmin: boolean;
+  onEdit: () => void;
+}) {
+  const mvp = match.mvpId
+    ? players.find((p) => p.id === match.mvpId)
+    : undefined;
+
+  if (!match.mvpId) {
+    if (!isAdmin) {
+      return (
+        <div className="flex items-center gap-1.5 text-gray-400 text-sm">
+          <TrophyIcon className="h-4 w-4" aria-hidden="true" />
+          <span>MVP no registrado</span>
+        </div>
+      );
+    }
+    return (
+      <button
+        type="button"
+        onClick={onEdit}
+        className="inline-flex items-center gap-1.5 text-sm px-2.5 py-1 rounded-full border border-dashed border-gray-300 text-gray-600 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] hover:bg-orange-50 transition"
+        aria-label="Asignar MVP a este partido"
+      >
+        <TrophyIcon className="h-4 w-4" aria-hidden="true" />
+        Asignar MVP
+      </button>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1.5 text-sm px-2.5 py-1 rounded-full bg-orange-50 border border-orange-200 text-orange-900">
+      <TrophyIcon
+        className="h-4 w-4 text-[var(--color-accent)]"
+        aria-hidden="true"
+      />
+      <span>
+        MVP: <span className="font-semibold">{mvp?.name ?? "—"}</span>
+      </span>
+      {isAdmin && (
+        <button
+          type="button"
+          onClick={onEdit}
+          className="ml-1 text-xs text-orange-700 hover:text-orange-900 underline"
+          aria-label={`Cambiar MVP de ${mvp?.name ?? "este partido"}`}
+        >
+          cambiar
+        </button>
+      )}
+    </div>
+  );
+}
+
+function MvpModal({
+  match,
+  players,
+  onClose,
+  onSave,
+}: {
+  match: Match;
+  players: Player[];
+  onClose: () => void;
+  onSave: (mvpId: string | null) => Promise<void>;
+}) {
+  const participants = useMemo(() => {
+    return [...match.teamA, ...match.teamB];
+  }, [match]);
+
+  const suggestedId = useMemo(() => {
+    const sorted = [...participants].sort(
+      (a, b) => b.performance - a.performance,
+    );
+    return sorted[0]?.id ?? null;
+  }, [participants]);
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    match.mvpId ?? suggestedId,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSave(selectedId);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "No se pudo guardar el MVP",
+      );
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mvp-modal-title"
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md max-h-[85vh] overflow-y-auto">
+        <div className="flex items-center justify-between px-5 py-4 border-b">
+          <div className="flex items-center gap-2">
+            <TrophyIcon
+              className="h-5 w-5 text-[var(--color-accent)]"
+              aria-hidden="true"
+            />
+            <h2 id="mvp-modal-title" className="text-lg font-semibold">
+              Elegir MVP del partido
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-800"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="p-5">
+          <p className="text-sm text-gray-600 mb-4">
+            Seleccioná al jugador más destacado del partido. Se sugiere el de
+            mayor performance.
+          </p>
+
+          <ul className="space-y-2" role="radiogroup" aria-label="Jugadores del partido">
+            {participants.map((p) => {
+              const isSelected = selectedId === p.id;
+              const isSuggested = p.id === suggestedId;
+              return (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => setSelectedId(p.id)}
+                    className={`w-full text-left flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg border transition ${
+                      isSelected
+                        ? "border-[var(--color-brand)] bg-purple-50 ring-1 ring-[var(--color-brand)]"
+                        : "border-gray-200 hover:bg-gray-50"
+                    }`}
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span
+                        className={`h-4 w-4 rounded-full border-2 flex-shrink-0 ${
+                          isSelected
+                            ? "border-[var(--color-brand)] bg-[var(--color-brand)]"
+                            : "border-gray-300"
+                        }`}
+                        aria-hidden="true"
+                      />
+                      <div className="min-w-0">
+                        <div className="font-medium truncate">{p.name}</div>
+                        <div className="text-xs text-gray-500">
+                          ⚽ {p.goals} · ★ {p.performance}
+                        </div>
+                      </div>
+                    </div>
+                    {isSuggested && (
+                      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-[var(--color-brand)] text-white flex-shrink-0">
+                        sugerido
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          {error && (
+            <div
+              role="alert"
+              className="mt-4 text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2"
+            >
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 px-5 py-4 border-t bg-gray-50 rounded-b-xl">
+          <button
+            type="button"
+            onClick={() => onSave(null).then(onClose).catch(() => {})}
+            disabled={isSaving || !match.mvpId}
+            className="text-sm text-gray-600 hover:text-red-700 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Quitar MVP
+          </button>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg border border-gray-300 hover:bg-gray-100 transition"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving || !selectedId}
+              aria-busy={isSaving}
+              className="px-4 py-2 rounded-lg bg-[var(--color-brand)] text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition"
+            >
+              {isSaving ? "Guardando..." : "Guardar MVP"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
+import { TrophyIcon } from "@heroicons/react/24/solid";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { useMatchStore } from "@/store/useMatchStore";
 import SkillBadge from "@/components/SkillBadge";
@@ -429,6 +430,13 @@ export default function PlayerDetailPage() {
         <div className="bg-white rounded-lg shadow p-4 text-center">
           <div className="text-sm text-gray-700">Llevo las Camisetas</div>
           <div className="text-2xl font-semibold">{player.shirtDutiesCount ?? 0} Veces</div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-4 text-center">
+          <div className="text-sm text-gray-700 flex items-center justify-center gap-1.5">
+            <TrophyIcon className="h-4 w-4 text-[var(--color-accent)]" aria-hidden="true" />
+            MVP del partido
+          </div>
+          <div className="text-2xl font-semibold">{player.mvpCount ?? 0} Veces</div>
         </div>
       </div>
 

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { TrophyIcon } from "@heroicons/react/24/solid";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { useMatchStore } from "@/store/useMatchStore";
 import SkillBadge from "@/components/SkillBadge";
@@ -433,7 +432,7 @@ export default function PlayerDetailPage() {
         </div>
         <div className="bg-white rounded-lg shadow p-4 text-center">
           <div className="text-sm text-gray-700 flex items-center justify-center gap-1.5">
-            <TrophyIcon className="h-4 w-4 text-[var(--color-accent)]" aria-hidden="true" />
+            <span aria-hidden="true">🏆</span>
             MVP del partido
           </div>
           <div className="text-2xl font-semibold">{player.mvpCount ?? 0} Veces</div>

--- a/apps/web/src/app/statistics/statisticsClient.tsx
+++ b/apps/web/src/app/statistics/statisticsClient.tsx
@@ -53,6 +53,7 @@ export default function StatisticsClient({
     losses: number;
     draws: number;
     shirts: number;
+    mvps: number;
   };
 
   const stats = useMemo<StatRow[]>(() => {
@@ -68,10 +69,14 @@ export default function StatisticsClient({
         losses: number;
         draws: number;
         shirts: number;
+        mvps: number;
       }
     > = {};
     const shirtCountById = new Map(
       players.map((p) => [p.id, p.shirtDutiesCount ?? 0]),
+    );
+    const mvpCountById = new Map(
+      players.map((p) => [p.id, p.mvpCount ?? 0]),
     );
     for (const m of matches) {
       const process =
@@ -93,6 +98,7 @@ export default function StatisticsClient({
               losses: 0,
               draws: 0,
               shirts: shirtCountById.get(p.id) ?? 0,
+              mvps: mvpCountById.get(p.id) ?? 0,
             };
           map[p.id].matches++;
           map[p.id].goals += p.goals;
@@ -246,13 +252,25 @@ export default function StatisticsClient({
                       : " ▼"
                     : ""}
                 </th>
+                <th
+                  className="px-4 py-3 text-left text-sm font-semibold text-gray-700 cursor-pointer select-none"
+                  onClick={() => toggleSort("mvps")}
+                  aria-label="Veces que fue MVP"
+                >
+                  🏆 MVP
+                  {sortKey === "mvps"
+                    ? sortDir === "asc"
+                      ? " ▲"
+                      : " ▼"
+                    : ""}
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {matches.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={8}
+                    colSpan={10}
                     className="px-4 py-8 text-center text-gray-800"
                   >
                     No hay estadísticas disponibles.
@@ -281,6 +299,7 @@ export default function StatisticsClient({
                         {stat.wins}W-{stat.losses}L-{stat.draws}D
                       </td>
                       <td className="px-4 py-3">{stat.shirts}</td>
+                      <td className="px-4 py-3 font-semibold">{stat.mvps}</td>
                     </tr>
                   );
                 })

--- a/apps/web/src/lib/shape.ts
+++ b/apps/web/src/lib/shape.ts
@@ -22,6 +22,8 @@ export function shapeStorePlayers(
     photoUrl: p.photoUrl ?? undefined,
     shirtDutiesCount:
       (p as unknown as { shirtDutiesCount?: number }).shirtDutiesCount ?? 0,
+    mvpCount:
+      (p as unknown as { mvpCount?: number }).mvpCount ?? 0,
     createdAt:
       p.createdAt instanceof Date ? p.createdAt : new Date(p.createdAt),
     updatedAt:
@@ -38,6 +40,7 @@ export function shapeStoreMatches(
     teamAScore: number;
     teamBScore: number;
     shirtsResponsibleId?: string | null;
+    mvpId?: string | null;
     players: Array<{
       playerId: string;
       team: "A" | "B";
@@ -53,6 +56,7 @@ export function shapeStoreMatches(
     type: m.type,
     name: m.name ?? undefined,
     shirtsResponsibleId: m.shirtsResponsibleId ?? undefined,
+    mvpId: m.mvpId ?? undefined,
     teamAScore: m.teamAScore,
     teamBScore: m.teamBScore,
     teamA: m.players

--- a/apps/web/src/store/useMatchStore.ts
+++ b/apps/web/src/store/useMatchStore.ts
@@ -8,6 +8,7 @@ type MatchStore = {
   initLoad: () => Promise<void>
   addMatch: (m: Omit<Match, 'id'>) => Promise<string>
   updateMatch: (id: string, m: Omit<Match, 'id'>) => Promise<void>
+  setMvp: (id: string, mvpId: string | null) => Promise<void>
   deleteMatch: (id: string) => Promise<void>
   hydrateMatches: (matches: Match[]) => void
   resetAndReload: () => Promise<void>
@@ -51,6 +52,16 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
     })
     if (!res.ok) throw new Error('Failed to update match')
     await get().resetAndReload()
+  },
+  setMvp: async (id, mvpId) => {
+    const res = await fetch(`/api/matches/${id}`, {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ mvpId })
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: 'Failed to set MVP' }))
+      throw new Error(body.error || 'Failed to set MVP')
+    }
+    set({ matches: get().matches.map(m => m.id === id ? { ...m, mvpId } : m) })
   },
   deleteMatch: async (id) => {
     await fetch(`/api/matches/${id}`, { method: 'DELETE' })

--- a/packages/types/src/match.ts
+++ b/packages/types/src/match.ts
@@ -15,6 +15,7 @@ export type Match = {
   teamB: MatchPlayer[]
   name?: string
   shirtsResponsibleId?: string | null
+  mvpId?: string | null
 }
 
 /** Minimal match shape used by streak-calculation algorithms */

--- a/packages/types/src/player.ts
+++ b/packages/types/src/player.ts
@@ -15,6 +15,7 @@ export type Player = {
   skills?: Skills
   photoUrl?: string
   shirtDutiesCount?: number
+  mvpCount?: number
   createdAt: Date
   updatedAt: Date
 }

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Usage: scripts/backup-db.sh [label]
+#   label: optional, gets appended to the backup filename for context.
+#          Useful before risky operations, e.g. `backup-db.sh pre_add_match_mvp`.
+#          Only [a-zA-Z0-9_-] are allowed; everything else is stripped.
+
 # ── Config ────────────────────────────────────────────────────────────────────
 BACKUP_DIR="$HOME/.fulbito-backups"
 MAX_BACKUPS=4
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-BACKUP_FILE="$BACKUP_DIR/fulbito_$TIMESTAMP.sql.gz"
+
+RAW_LABEL="${1:-}"
+LABEL="$(printf '%s' "$RAW_LABEL" | tr -cd '[:alnum:]_-')"
+LABEL_SUFFIX=""
+[[ -n "$LABEL" ]] && LABEL_SUFFIX="_$LABEL"
+
+BACKUP_FILE="$BACKUP_DIR/fulbito_${TIMESTAMP}${LABEL_SUFFIX}.sql.gz"
 
 # Load DATABASE_URL from backend .env if not already set
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -49,7 +60,11 @@ echo "🗄️  Starting backup → $BACKUP_FILE"
 echo "✅  Backup complete ($(du -sh "$BACKUP_FILE" | cut -f1))"
 
 # ── Rotate: keep only last MAX_BACKUPS ────────────────────────────────────────
-mapfile -t OLD_BACKUPS < <(ls -t "$BACKUP_DIR"/fulbito_*.sql.gz 2>/dev/null | tail -n +$((MAX_BACKUPS + 1)))
+# Portable replacement for `mapfile` (not available in macOS's default bash 3.2).
+OLD_BACKUPS=()
+while IFS= read -r line; do
+  OLD_BACKUPS+=("$line")
+done < <(ls -t "$BACKUP_DIR"/fulbito_*.sql.gz 2>/dev/null | tail -n +$((MAX_BACKUPS + 1)))
 
 if [[ ${#OLD_BACKUPS[@]} -gt 0 ]]; then
   echo "🗑️  Removing ${#OLD_BACKUPS[@]} old backup(s):"


### PR DESCRIPTION
## Summary
- Adds MVP selection per match on the web history view, plus aggregated MVP counts in statistics and player profiles.
- New DB fields `Match.mvpId` (nullable FK, `ON DELETE SET NULL`) and `Player.mvpCount`, mirroring the existing shirt-duty pattern.
- Atomic `mvpCount` upkeep on create/update/delete with server-side validation (MVP must belong to the match).

Part of #60. Mobile follow-up tracked in #62.

## Changes

### Backend
- Prisma schema: `Match.mvpId` / `Match.mvp` relation, `Player.mvpCount`, `Player.mvpMatches`.
- Migration `20260512105249_add_match_mvp` (additive, no backfill).
- `POST` / `PUT /api/matches` accept `mvpId`, validate it belongs to the participants, increment/decrement `mvpCount` in a single transaction.
- `DELETE /api/matches/[id]` now also rolls back `mvpCount` before deletion.

### Web
- **History card**: new orange MVP chip with trophy icon. Admin gets "Asignar MVP" / "cambiar" / "Quitar MVP". Non-admin sees a read-only "MVP no registrado" or the MVP name.
- **MVP modal**: radio-style selection, lists only the match's participants, pre-selects the player with the highest performance with a "sugerido" purple chip. `aria-modal`, `role="radiogroup"`.
- **Record modal** (create/edit): MVP selector below shirt duty. Auto-clears the value if the selected player is removed from the teams during edit.
- **Statistics table**: new sortable `🏆 MVP` column.
- **Player profile**: new "MVP del partido" stat card with trophy icon in `var(--color-accent)`.

### Shared & infra
- `@fulbito/types`: `Match.mvpId`, `Player.mvpCount`.
- `useMatchStore`: dedicated `setMvp(matchId, mvpId)` action with optimistic update.
- `scripts/backup-db.sh`: accepts an optional label argument and fixes a bash-3.2 `mapfile` portability bug that broke rotation on macOS.

## Mobile — out of scope (intentional)
The mobile app's history screen (`apps/mobile/app/(tabs)/history.tsx`) is still a stub, so there's nothing to wire the MVP selector into. Doing it now would mean building the screen first, which expands scope. Tracked in #62.

**Things to keep in mind when implementing on mobile**:
- Mirror the data shape — the API and types already include `mvpId`/`mvpCount`, no backend changes needed.
- Use the project's theme tokens (`Colors.brand` for selection, `Colors.secondary` for the trophy icon, `Colors.muted` for empty state).
- Use a bottom sheet (Reanimated) instead of a centered modal — better mobile UX.
- Touch targets minimum 44×44, `accessibilityRole=\"button\"`, `accessibilityState={{ selected }}`.
- Replicate the auto-suggest behaviour: pre-select the highest performance player.

## Migration & deployment notes
- Migration is **additive** (nullable column + default 0 + FK with `SET NULL`). No data loss, no backfill required.
- The shared Neon DB has been migrated and the `_prisma_migrations` table updated via `prisma migrate resolve --applied`.
- **Teammates must run `pnpm install` + `pnpm prisma generate` from `apps/backend/`** after pulling. They should NOT run `migrate dev` (the DB is already up to date).
- Pre-migration backup taken: `~/.fulbito-backups/fulbito_20260512_104619_pre_add_match_mvp.sql.gz`.

## Test plan
- [ ] Web: assign an MVP to a match without one → chip shows the player name.
- [ ] Web: change MVP from one player to another → previous player's `mvpCount` decrements, new player's increments (verify in Prisma Studio).
- [ ] Web: "Quitar MVP" sets the chip back to "Asignar MVP" and `mvpCount` decrements.
- [ ] Web (admin only): non-admin user sees only the read-only chip, no buttons.
- [ ] Record modal: create a new match with an MVP; verify it persists.
- [ ] Record modal: edit a match, remove the MVP from the teams → MVP field auto-clears, save succeeds.
- [ ] Stats table: new `🏆 MVP` column appears and sorts.
- [ ] Player profile: "MVP del partido" stat card shows the correct count.
- [ ] Backend validation: `PUT /api/matches/<id>` with an `mvpId` not in the match returns 400.

<img width="1728" height="1117" alt="Screenshot 2026-05-12 at 7 04 19 PM" src="https://github.com/user-attachments/assets/7dd79d0b-6d63-4330-ba8d-6180e668a902" />
<img width="1728" height="1117" alt="Screenshot 2026-05-12 at 7 04 54 PM" src="https://github.com/user-attachments/assets/868c776d-9c96-4d44-82b4-e494306500c8" />
<img width="1728" height="1117" alt="Screenshot 2026-05-12 at 7 05 20 PM" src="https://github.com/user-attachments/assets/d419dccd-5a5f-4770-8566-cf5da635b3a8" />

