### PR TITLE
feat(mobile): player detail and edit screens 

### DIFF
--- a/apps/mobile/app/(tabs)/players/[id].tsx
+++ b/apps/mobile/app/(tabs)/players/[id].tsx
@@ -1,25 +1,325 @@
-import { Text, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useLocalSearchParams } from 'expo-router';
+import { LinearGradient } from 'expo-linear-gradient'
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
+import { useLayoutEffect } from 'react'
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import MaterialIcons from '@expo/vector-icons/MaterialIcons'
+
+import { PlayerAvatar } from '@/components/players/player-avatar'
+import { SkillBadge } from '@/components/players/skill-badge'
+import { StreakBadge } from '@/components/players/streak-badge'
+import { PlayerSkillBars } from '@/components/players/detail/player-skill-bars'
+import { PlayerStatsGrid } from '@/components/players/detail/player-stats-grid'
+import { RecentMatchRow } from '@/components/players/detail/recent-match-row'
+import { ThemedText } from '@/components/themed-text'
+import { ThemedView } from '@/components/themed-view'
+import { useIsAdmin } from '@/hooks/use-is-admin'
+import { usePlayerDetail } from '@/hooks/use-player-detail'
+import { useAppTheme } from '@/hooks/use-theme'
+import { Fonts, Radii, Spacing } from '@/constants/theme'
+
+const AVATAR_SIZE = 80
+const RECENT_MAX = 10
 
 export default function PlayerDetailScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const navigation = useNavigation()
+  const router = useRouter()
+  const isAdmin = useIsAdmin()
+  const { colors, isDark, shadows } = useAppTheme()
+
+  const { player, stats, streak, catSkills, overallAvg, loading, refreshing, error, refresh, reload } =
+    usePlayerDetail(id)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: player?.name ?? 'Jugador',
+      headerRight: isAdmin
+        ? () => (
+            <Pressable
+              onPress={() => router.push(`/(tabs)/players/edit/${id}`)}
+              style={styles.editBtn}>
+              <MaterialIcons name="edit" size={20} color={colors.brand} />
+            </Pressable>
+          )
+        : undefined,
+    })
+  }, [navigation, player?.name, isAdmin, router, id, colors.brand])
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.centered, { backgroundColor: colors.background }]} edges={['bottom']}>
+        <ActivityIndicator color={colors.brand} size="large" />
+      </SafeAreaView>
+    )
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={[styles.centered, { backgroundColor: colors.background }]} edges={['bottom']}>
+        <ThemedText style={styles.errorText}>{error}</ThemedText>
+        <Pressable onPress={() => void reload()} style={[styles.retryBtn, { backgroundColor: colors.brand }]}>
+          <ThemedText style={styles.retryText}>Reintentar</ThemedText>
+        </Pressable>
+      </SafeAreaView>
+    )
+  }
+
+  if (!player) {
+    return (
+      <SafeAreaView style={[styles.centered, { backgroundColor: colors.background }]} edges={['bottom']}>
+        <ThemedText style={styles.errorText}>Jugador no encontrado.</ThemedText>
+        <Pressable onPress={() => router.back()} style={[styles.retryBtn, { backgroundColor: colors.brand }]}>
+          <ThemedText style={styles.retryText}>Volver</ThemedText>
+        </Pressable>
+      </SafeAreaView>
+    )
+  }
+
+  const recentSlice = stats.recent.slice(0, RECENT_MAX)
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom']}>
-      <Text style={styles.title}>/players/{id}</Text>
+    <SafeAreaView style={[styles.safe, { backgroundColor: colors.background }]} edges={['bottom']}>
+      <ThemedView style={styles.screen}>
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.scroll}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => void refresh()}
+              tintColor={colors.brand}
+            />
+          }>
+
+          {/* ── Hero ─────────────────────────────────────────── */}
+          <LinearGradient
+            colors={['#7C3AED', '#F97316']}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.hero}>
+            {/* Izquierda: avatar + nombre + posición + racha */}
+            <View style={styles.heroLeft}>
+              <PlayerAvatar name={player.name} photoUrl={player.photoUrl} size={AVATAR_SIZE} />
+              <View style={styles.heroInfo}>
+                <Text style={styles.playerName}>{player.name}</Text>
+                <View style={styles.heroMeta}>
+                  <Text style={styles.position}>{player.position}</Text>
+                  {streak.kind ? (
+                    <StreakBadge kind={streak.kind} count={streak.count} />
+                  ) : null}
+                </View>
+              </View>
+            </View>
+            {/* Derecha: skill overall */}
+            <View style={styles.skillPill}>
+              <Text style={styles.skillPillLabel}>OVERALL</Text>
+              <Text style={styles.skillPillText}>Lv {overallAvg.toFixed(1)}</Text>
+            </View>
+          </LinearGradient>
+
+          {/* ── Stats ────────────────────────────────────────── */}
+          <SectionTitle title="Estadísticas" />
+          <PlayerStatsGrid stats={stats} />
+
+          {/* ── Habilidades ──────────────────────────────────── */}
+          <SectionTitle title="Habilidades" />
+          <View
+            style={[
+              styles.card,
+              { backgroundColor: colors.surface, borderColor: colors.border },
+              shadows.card(isDark),
+            ]}>
+            <PlayerSkillBars skills={catSkills} />
+          </View>
+
+          {/* ── Últimos partidos ─────────────────────────────── */}
+          {recentSlice.length > 0 ? (
+            <>
+              <SectionTitle title={`Últimos partidos (${stats.matches})`} />
+              <View
+                style={[
+                  styles.card,
+                  styles.matchesCard,
+                  { backgroundColor: colors.surface, borderColor: colors.border },
+                  shadows.card(isDark),
+                ]}>
+                {recentSlice.map((m, i) => (
+                  <RecentMatchRow
+                    key={m.id}
+                    match={m}
+                    showBorder={i < recentSlice.length - 1}
+                  />
+                ))}
+              </View>
+            </>
+          ) : (
+            <>
+              <SectionTitle title="Últimos partidos" />
+              <View style={[styles.emptyCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+                <MaterialIcons name="sports-soccer" size={32} color={colors.muted} />
+                <ThemedText style={[styles.emptyText, { color: colors.muted }]}>
+                  Sin partidos registrados
+                </ThemedText>
+              </View>
+            </>
+          )}
+
+          <View style={styles.bottomPad} />
+        </ScrollView>
+      </ThemedView>
     </SafeAreaView>
-  );
+  )
+}
+
+function SectionTitle({ title }: { title: string }) {
+  const { colors } = useAppTheme()
+  return (
+    <ThemedText style={[styles.sectionTitle, { color: colors.text }]}>{title.toUpperCase()}</ThemedText>
+  )
 }
 
 const styles = StyleSheet.create({
-  container: {
+  safe: { flex: 1 },
+  screen: { flex: 1 },
+  centered: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    gap: Spacing.md,
+    paddingHorizontal: Spacing.xxl,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  scroll: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.xxxl,
   },
-});
+
+  /* Hero */
+  hero: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: Radii.lg,
+    paddingVertical: Spacing.xl,
+    paddingHorizontal: Spacing.lg,
+    marginBottom: Spacing.xl,
+  },
+  heroLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    flex: 1,
+  },
+  heroInfo: {
+    flex: 1,
+    gap: Spacing.xs,
+  },
+  playerName: {
+    fontSize: 20,
+    fontFamily: Fonts.extraBold,
+    letterSpacing: -0.3,
+    color: '#fff',
+  },
+  heroMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  position: {
+    fontSize: 11,
+    fontFamily: Fonts.bold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    color: 'rgba(255,255,255,0.75)',
+  },
+  skillPill: {
+    backgroundColor: 'rgba(255,255,255,0.18)',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: Radii.md,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+    alignItems: 'center',
+    gap: 2,
+  },
+  skillPillLabel: {
+    color: 'rgba(255,255,255,0.7)',
+    fontSize: 9,
+    fontFamily: Fonts.bold,
+    letterSpacing: 1,
+  },
+  skillPillText: {
+    color: '#fff',
+    fontSize: 16,
+    fontFamily: Fonts.black,
+    letterSpacing: 0.2,
+  },
+
+  /* Section title */
+  sectionTitle: {
+    fontFamily: Fonts.blackItalic,
+    fontSize: 13,
+    letterSpacing: 0.8,
+    marginBottom: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+
+  /* Generic card */
+  card: {
+    borderWidth: 1,
+    borderRadius: Radii.lg,
+    padding: Spacing.lg,
+    marginBottom: Spacing.xl,
+  },
+  matchesCard: {
+    padding: 0,
+    overflow: 'hidden',
+  },
+
+  /* Empty state */
+  emptyCard: {
+    borderWidth: 1,
+    borderRadius: Radii.lg,
+    paddingVertical: Spacing.xxxl,
+    marginBottom: Spacing.xl,
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontFamily: Fonts.medium,
+  },
+
+  /* Error / retry */
+  errorText: {
+    fontSize: 15,
+    textAlign: 'center',
+    marginBottom: Spacing.md,
+  },
+  retryBtn: {
+    paddingHorizontal: Spacing.xl,
+    paddingVertical: Spacing.sm,
+    borderRadius: Radii.pill,
+  },
+  retryText: {
+    color: '#fff',
+    fontFamily: Fonts.semiBold,
+    fontSize: 15,
+  },
+
+  bottomPad: { height: 16 },
+
+  editBtn: {
+    padding: 6,
+    marginRight: 4,
+  },
+})

--- a/apps/mobile/app/(tabs)/players/[id].tsx
+++ b/apps/mobile/app/(tabs)/players/[id].tsx
@@ -14,7 +14,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import MaterialIcons from '@expo/vector-icons/MaterialIcons'
 
 import { PlayerAvatar } from '@/components/players/player-avatar'
-import { SkillBadge } from '@/components/players/skill-badge'
 import { StreakBadge } from '@/components/players/streak-badge'
 import { PlayerSkillBars } from '@/components/players/detail/player-skill-bars'
 import { PlayerStatsGrid } from '@/components/players/detail/player-stats-grid'

--- a/apps/mobile/app/(tabs)/players/edit/[id].tsx
+++ b/apps/mobile/app/(tabs)/players/edit/[id].tsx
@@ -1,25 +1,101 @@
-import { Text, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { Alert, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import { PlayerEditForm, type PlayerEditFormValues } from '@/components/players/edit/player-edit-form'
+import { useIsAdmin } from '@/hooks/use-is-admin'
+import { usePlayersData } from '@/hooks/use-players-data'
+import { updatePlayerRequest } from '@/lib/api'
+import { useAppTheme } from '@/hooks/use-theme'
 
 export default function EditPlayerScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const navigation = useNavigation()
+  const router = useRouter()
+  const isAdmin = useIsAdmin()
+  const { colors } = useAppTheme()
+
+  const { players, reload } = usePlayersData()
+  const player = players.find((p) => p.id === id) ?? null
+
+  const [values, setValues] = useState<PlayerEditFormValues>({
+    name: '',
+    position: 'PLAYER',
+    physical: 5,
+    technical: 5,
+    tactical: 5,
+    psychological: 5,
+  })
+  const [saving, setSaving] = useState(false)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: 'Editar jugador' })
+  }, [navigation])
+
+  useEffect(() => {
+    if (!isAdmin) {
+      Alert.alert('Sin permisos', 'Solo los administradores pueden editar jugadores.', [
+        { text: 'Volver', onPress: () => router.back() },
+      ])
+    }
+  }, [isAdmin, router])
+
+  useEffect(() => {
+    if (player) {
+      const base = player.skill ?? 5
+      setValues({
+        name: player.name,
+        position: player.position,
+        physical: Number(player.skills?.physical ?? base),
+        technical: Number(player.skills?.technical ?? base),
+        tactical: Number(player.skills?.tactical ?? base),
+        psychological: Number(player.skills?.psychological ?? base),
+      })
+    }
+  }, [player])
+
+  const handleSave = useCallback(async () => {
+    if (!id) return
+    setSaving(true)
+    try {
+      const skills = {
+        physical: values.physical,
+        technical: values.technical,
+        tactical: values.tactical,
+        psychological: values.psychological,
+      }
+      const skill = (skills.physical + skills.technical + skills.tactical + skills.psychological) / 4
+      await updatePlayerRequest(id, {
+        name: values.name.trim(),
+        position: values.position,
+        skills,
+        skill,
+      })
+      await reload()
+      router.back()
+    } catch (e) {
+      Alert.alert('Error', e instanceof Error ? e.message : 'No se pudo actualizar el jugador.')
+    } finally {
+      setSaving(false)
+    }
+  }, [id, values, reload, router])
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom']}>
-      <Text style={styles.title}>/players/edit/{id}</Text>
+    <SafeAreaView
+      style={[styles.safe, { backgroundColor: colors.background }]}
+      edges={['bottom']}>
+      <PlayerEditForm
+        values={values}
+        onChange={setValues}
+        saving={saving}
+        onSave={() => void handleSave()}
+        onCancel={() => router.back()}
+      />
     </SafeAreaView>
-  );
+  )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-  },
-});
+  safe: { flex: 1 },
+})

--- a/apps/mobile/components/players/detail/player-skill-bars.tsx
+++ b/apps/mobile/components/players/detail/player-skill-bars.tsx
@@ -1,0 +1,90 @@
+import { StyleSheet, View } from 'react-native'
+
+import { ThemedText } from '@/components/themed-text'
+import type { CatSkills } from '@/hooks/use-player-detail'
+import { useAppTheme } from '@/hooks/use-theme'
+import { Fonts, Radii, Spacing } from '@/constants/theme'
+
+type Props = {
+  skills: CatSkills
+}
+
+type SkillRowProps = {
+  label: string
+  value: number
+}
+
+const MAX = 10
+
+function skillColor(value: number): string {
+  if (value <= 5) {
+    const t = (Math.max(1, value) - 1) / 4
+    const l = 38 + 14 * t
+    return `hsl(24, 85%, ${l}%)`
+  }
+  const t = (Math.min(10, value) - 6) / 4
+  const l = 50 - 14 * t
+  return `hsl(270, 78%, ${l}%)`
+}
+
+function SkillRow({ label, value }: SkillRowProps) {
+  const { colors } = useAppTheme()
+  const pct = (value / MAX) * 100
+  const color = skillColor(value)
+
+  return (
+    <View style={styles.row}>
+      <ThemedText style={[styles.label, { color: colors.muted }]}>{label}</ThemedText>
+      <View style={[styles.track, { backgroundColor: colors.chipBg, borderColor: colors.chipBorder }]}>
+        <View style={[styles.fill, { width: `${pct}%`, backgroundColor: color }]} />
+      </View>
+      <ThemedText style={[styles.value, { color: colors.text }]}>{value.toFixed(1)}</ThemedText>
+    </View>
+  )
+}
+
+export function PlayerSkillBars({ skills }: Props) {
+  return (
+    <View style={styles.container}>
+      <SkillRow label="Físico" value={skills.physical} />
+      <SkillRow label="Técnico" value={skills.technical} />
+      <SkillRow label="Táctico" value={skills.tactical} />
+      <SkillRow label="Mental" value={skills.psychological} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: Spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  label: {
+    width: 64,
+    fontSize: 12,
+    fontFamily: Fonts.semiBold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  track: {
+    flex: 1,
+    height: 8,
+    borderRadius: Radii.pill,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: Radii.pill,
+  },
+  value: {
+    width: 32,
+    fontSize: 13,
+    fontFamily: Fonts.bold,
+    textAlign: 'right',
+  },
+})

--- a/apps/mobile/components/players/detail/player-stats-grid.tsx
+++ b/apps/mobile/components/players/detail/player-stats-grid.tsx
@@ -1,0 +1,97 @@
+import { StyleSheet, View } from 'react-native'
+
+import { ThemedText } from '@/components/themed-text'
+import type { PlayerDetailStats } from '@/hooks/use-player-detail'
+import { useAppTheme } from '@/hooks/use-theme'
+import { Fonts, Radii, Spacing } from '@/constants/theme'
+
+type Props = {
+  stats: PlayerDetailStats
+}
+
+type StatBoxProps = {
+  label: string
+  value: string
+  sub?: string
+  accent?: string
+}
+
+function StatBox({ label, value, sub, accent }: StatBoxProps) {
+  const { colors, isDark, shadows } = useAppTheme()
+  return (
+    <View
+      style={[
+        styles.box,
+        {
+          backgroundColor: colors.surface,
+          borderColor: colors.border,
+        },
+        shadows.card(isDark),
+      ]}>
+      <ThemedText style={[styles.value, { color: accent ?? colors.text }]}>{value}</ThemedText>
+      {sub ? (
+        <ThemedText style={[styles.sub, { color: colors.muted }]}>{sub}</ThemedText>
+      ) : null}
+      <ThemedText style={[styles.label, { color: colors.muted }]}>{label}</ThemedText>
+    </View>
+  )
+}
+
+export function PlayerStatsGrid({ stats }: Props) {
+  const { colors } = useAppTheme()
+
+  const winsColor =
+    stats.wins > stats.losses ? '#16a34a' : stats.losses > stats.wins ? colors.danger : colors.muted
+
+  return (
+    <View style={styles.grid}>
+      <StatBox label="Partidos" value={String(stats.matches)} />
+      <StatBox label="Goles" value={String(stats.goals)} sub={`${stats.gpm}/p`} />
+      <StatBox
+        label="Victorias"
+        value={String(stats.wins)}
+        sub={`${stats.winRate}%`}
+        accent={winsColor}
+      />
+      <StatBox
+        label="Rendimiento"
+        value={stats.avgPerformance.toFixed(1)}
+        sub={`W${stats.wins} D${stats.draws} L${stats.losses}`}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  box: {
+    flex: 1,
+    minWidth: '45%',
+    borderWidth: 1,
+    borderRadius: Radii.md,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    alignItems: 'center',
+    gap: 2,
+  },
+  value: {
+    fontSize: 22,
+    fontFamily: Fonts.extraBold,
+    letterSpacing: -0.5,
+  },
+  sub: {
+    fontSize: 11,
+    fontFamily: Fonts.semiBold,
+  },
+  label: {
+    fontSize: 10,
+    fontFamily: Fonts.semiBold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 2,
+  },
+})

--- a/apps/mobile/components/players/detail/recent-match-row.tsx
+++ b/apps/mobile/components/players/detail/recent-match-row.tsx
@@ -1,0 +1,124 @@
+import { StyleSheet, View } from 'react-native'
+
+import { ThemedText } from '@/components/themed-text'
+import type { RecentMatchEntry } from '@/hooks/use-player-detail'
+import { useAppTheme } from '@/hooks/use-theme'
+import { Fonts, Radii, Spacing } from '@/constants/theme'
+
+type Props = {
+  match: RecentMatchEntry
+  showBorder?: boolean
+}
+
+function resultColor(result: 'W' | 'L' | 'D'): string {
+  if (result === 'W') return '#16a34a'
+  if (result === 'L') return '#dc2626'
+  return '#6b7280'
+}
+
+function resultLabel(result: 'W' | 'L' | 'D'): string {
+  if (result === 'W') return 'V'
+  if (result === 'L') return 'D'
+  return 'E'
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    const d = new Date(dateStr)
+    return d.toLocaleDateString('es-AR', { day: '2-digit', month: 'short' }).toUpperCase()
+  } catch {
+    return dateStr.slice(0, 10)
+  }
+}
+
+export function RecentMatchRow({ match, showBorder = true }: Props) {
+  const { colors } = useAppTheme()
+  const color = resultColor(match.result)
+  const label = resultLabel(match.result)
+
+  return (
+    <View
+      style={[
+        styles.row,
+        showBorder && { borderBottomWidth: 1, borderBottomColor: colors.border },
+      ]}>
+      {/* Result badge */}
+      <View style={[styles.badge, { backgroundColor: `${color}22` }]}>
+        <ThemedText style={[styles.badgeText, { color }]}>{label}</ThemedText>
+      </View>
+
+      {/* Date + type */}
+      <View style={styles.meta}>
+        <ThemedText style={[styles.date, { color: colors.text }]}>
+          {formatDate(match.date)}
+        </ThemedText>
+        <ThemedText style={[styles.type, { color: colors.muted }]}>
+          {match.type} · Equipo {match.team}
+        </ThemedText>
+      </View>
+
+      {/* Score */}
+      <ThemedText style={[styles.score, { color: colors.muted }]}>{match.score}</ThemedText>
+
+      {/* Goals + Performance */}
+      <View style={styles.stats}>
+        <ThemedText style={[styles.statValue, { color: colors.text }]}>
+          {match.goals}G
+        </ThemedText>
+        <ThemedText style={[styles.statValue, { color: colors.muted }]}>
+          {match.performance.toFixed(0)}R
+        </ThemedText>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.sm + 2,
+    paddingHorizontal: Spacing.md,
+  },
+  badge: {
+    width: 28,
+    height: 28,
+    borderRadius: Radii.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: {
+    fontSize: 12,
+    fontFamily: Fonts.black,
+  },
+  meta: {
+    flex: 1,
+    minWidth: 0,
+  },
+  date: {
+    fontSize: 13,
+    fontFamily: Fonts.semiBold,
+  },
+  type: {
+    fontSize: 10,
+    fontFamily: Fonts.medium,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+    marginTop: 1,
+  },
+  score: {
+    fontSize: 13,
+    fontFamily: Fonts.bold,
+    minWidth: 48,
+    textAlign: 'center',
+  },
+  stats: {
+    alignItems: 'flex-end',
+    gap: 2,
+  },
+  statValue: {
+    fontSize: 12,
+    fontFamily: Fonts.semiBold,
+  },
+})

--- a/apps/mobile/components/players/edit/player-edit-form.tsx
+++ b/apps/mobile/components/players/edit/player-edit-form.tsx
@@ -1,0 +1,327 @@
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+
+import { ThemedText } from '@/components/themed-text'
+import { useAppTheme } from '@/hooks/use-theme'
+import { Fonts, Radii, Spacing } from '@/constants/theme'
+
+export type PlayerEditFormValues = {
+  name: string
+  position: string
+  physical: number
+  technical: number
+  tactical: number
+  psychological: number
+}
+
+type Props = {
+  values: PlayerEditFormValues
+  onChange: (values: PlayerEditFormValues) => void
+  saving: boolean
+  onSave: () => void
+  onCancel: () => void
+}
+
+const POSITIONS = [
+  { value: 'GK', label: 'Arquero' },
+  { value: 'DEF', label: 'Defensor' },
+  { value: 'MID', label: 'Mediocampista' },
+  { value: 'FWD', label: 'Delantero' },
+  { value: 'PLAYER', label: 'Cualquier posición' },
+]
+
+const SKILL_KEYS: { key: keyof PlayerEditFormValues; label: string }[] = [
+  { key: 'physical', label: 'Físico' },
+  { key: 'technical', label: 'Técnico' },
+  { key: 'tactical', label: 'Táctico' },
+  { key: 'psychological', label: 'Mental' },
+]
+
+function SkillStepper({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: number
+  onChange: (v: number) => void
+}) {
+  const { colors, radii } = useAppTheme()
+  return (
+    <View style={styles.stepperRow}>
+      <ThemedText style={[styles.stepperLabel, { color: colors.muted }]}>{label}</ThemedText>
+      <View style={[styles.stepper, { borderColor: colors.border, borderRadius: radii.sm }]}>
+        <TouchableOpacity
+          onPress={() => onChange(Math.max(1, value - 1))}
+          style={[styles.stepBtn, { borderRightColor: colors.border }]}
+          hitSlop={8}>
+          <ThemedText style={[styles.stepBtnText, { color: colors.brand }]}>−</ThemedText>
+        </TouchableOpacity>
+        <ThemedText style={[styles.stepValue, { color: colors.text }]}>{value}</ThemedText>
+        <TouchableOpacity
+          onPress={() => onChange(Math.min(10, value + 1))}
+          style={[styles.stepBtn, { borderLeftColor: colors.border }]}
+          hitSlop={8}>
+          <ThemedText style={[styles.stepBtnText, { color: colors.brand }]}>+</ThemedText>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+export function PlayerEditForm({ values, onChange, saving, onSave, onCancel }: Props) {
+  const { colors, radii } = useAppTheme()
+
+  const overall =
+    (values.physical + values.technical + values.tactical + values.psychological) / 4
+
+  const canSave = values.name.trim().length >= 2 && !saving
+
+  const set = (key: keyof PlayerEditFormValues, val: string | number) =>
+    onChange({ ...values, [key]: val })
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}>
+
+        {/* ── Nombre ──────────────────────────────────────── */}
+        <ThemedText style={[styles.label, { color: colors.muted }]}>Nombre</ThemedText>
+        <TextInput
+          value={values.name}
+          onChangeText={(v) => set('name', v)}
+          autoCapitalize="words"
+          autoCorrect={false}
+          placeholder="Nombre del jugador"
+          placeholderTextColor={colors.muted}
+          style={[
+            styles.textInput,
+            {
+              borderColor: colors.border,
+              borderRadius: radii.sm,
+              color: colors.text,
+              backgroundColor: colors.surface,
+            },
+          ]}
+        />
+
+        {/* ── Posición ─────────────────────────────────────── */}
+        <ThemedText style={[styles.label, { color: colors.muted }]}>Posición</ThemedText>
+        <View style={styles.chips}>
+          {POSITIONS.map((p) => {
+            const active = values.position === p.value
+            return (
+              <TouchableOpacity
+                key={p.value}
+                onPress={() => set('position', p.value)}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: active ? colors.brand : 'transparent',
+                    borderColor: active ? colors.brand : colors.border,
+                    borderRadius: radii.sm,
+                  },
+                ]}>
+                <ThemedText
+                  style={[styles.chipText, { color: active ? '#fff' : colors.muted }]}>
+                  {p.label}
+                </ThemedText>
+              </TouchableOpacity>
+            )
+          })}
+        </View>
+
+        {/* ── Habilidades ──────────────────────────────────── */}
+        <ThemedText style={[styles.label, { color: colors.muted }]}>Habilidades</ThemedText>
+        <View
+          style={[
+            styles.skillsCard,
+            { backgroundColor: colors.surface, borderColor: colors.border, borderRadius: radii.md },
+          ]}>
+          {SKILL_KEYS.map(({ key, label }) => (
+            <SkillStepper
+              key={key}
+              label={label}
+              value={values[key] as number}
+              onChange={(v) => set(key, v)}
+            />
+          ))}
+        </View>
+
+        {/* ── Promedio ─────────────────────────────────────── */}
+        <View style={[styles.avgRow, { borderColor: colors.border, borderRadius: radii.sm }]}>
+          <ThemedText style={[styles.avgLabel, { color: colors.muted }]}>General (promedio)</ThemedText>
+          <ThemedText style={[styles.avgValue, { color: colors.brand }]}>
+            Lv {overall.toFixed(2)}
+          </ThemedText>
+        </View>
+
+        {/* ── Acciones ─────────────────────────────────────── */}
+        <View style={styles.actions}>
+          <TouchableOpacity
+            onPress={onCancel}
+            style={[styles.cancelBtn, { borderColor: colors.border, borderRadius: radii.sm }]}>
+            <ThemedText style={[styles.cancelText, { color: colors.text }]}>Cancelar</ThemedText>
+          </TouchableOpacity>
+          <Pressable
+            onPress={onSave}
+            disabled={!canSave}
+            style={[
+              styles.saveBtn,
+              {
+                backgroundColor: canSave ? colors.brand : colors.muted,
+                borderRadius: radii.sm,
+              },
+            ]}>
+            {saving ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <ThemedText style={styles.saveText}>Actualizar jugador</ThemedText>
+            )}
+          </Pressable>
+        </View>
+
+        <View style={styles.bottomPad} />
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  scroll: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.lg,
+  },
+
+  label: {
+    fontSize: 13,
+    fontFamily: Fonts.semiBold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: Spacing.xs,
+    marginTop: Spacing.lg,
+  },
+
+  textInput: {
+    borderWidth: 1,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Platform.OS === 'ios' ? 13 : 10,
+    fontSize: 16,
+    fontFamily: Fonts.medium,
+  },
+
+  chips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  chip: {
+    borderWidth: 1,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs + 2,
+  },
+  chipText: {
+    fontSize: 13,
+    fontFamily: Fonts.semiBold,
+  },
+
+  skillsCard: {
+    borderWidth: 1,
+    paddingVertical: Spacing.xs,
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+  },
+  stepperLabel: {
+    fontSize: 14,
+    fontFamily: Fonts.semiBold,
+    flex: 1,
+  },
+  stepper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  stepBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderWidth: 0,
+  },
+  stepBtnText: {
+    fontSize: 18,
+    fontFamily: Fonts.bold,
+    lineHeight: 22,
+  },
+  stepValue: {
+    width: 36,
+    textAlign: 'center',
+    fontSize: 15,
+    fontFamily: Fonts.bold,
+  },
+
+  avgRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    marginTop: Spacing.lg,
+  },
+  avgLabel: {
+    fontSize: 13,
+    fontFamily: Fonts.medium,
+  },
+  avgValue: {
+    fontSize: 15,
+    fontFamily: Fonts.extraBold,
+  },
+
+  actions: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xl,
+  },
+  cancelBtn: {
+    flex: 1,
+    borderWidth: 1,
+    paddingVertical: 13,
+    alignItems: 'center',
+  },
+  cancelText: {
+    fontSize: 14,
+    fontFamily: Fonts.semiBold,
+  },
+  saveBtn: {
+    flex: 2,
+    paddingVertical: 13,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  saveText: {
+    color: '#fff',
+    fontSize: 14,
+    fontFamily: Fonts.bold,
+  },
+
+  bottomPad: { height: 32 },
+})

--- a/apps/mobile/components/players/edit/player-edit-form.tsx
+++ b/apps/mobile/components/players/edit/player-edit-form.tsx
@@ -12,7 +12,7 @@ import {
 
 import { ThemedText } from '@/components/themed-text'
 import { useAppTheme } from '@/hooks/use-theme'
-import { Fonts, Radii, Spacing } from '@/constants/theme'
+import { Fonts, Spacing } from '@/constants/theme'
 
 export type PlayerEditFormValues = {
   name: string

--- a/apps/mobile/hooks/use-player-detail.ts
+++ b/apps/mobile/hooks/use-player-detail.ts
@@ -1,0 +1,141 @@
+import type { Match } from '@fulbito/types'
+import { calculateCurrentStreakForPlayer } from '@fulbito/utils'
+import { useMemo } from 'react'
+
+import { usePlayersData } from '@/hooks/use-players-data'
+
+export type RecentMatchEntry = {
+  id: string
+  date: string
+  type: string
+  team: 'A' | 'B'
+  goals: number
+  performance: number
+  score: string
+  result: 'W' | 'L' | 'D'
+}
+
+export type PlayerDetailStats = {
+  matches: number
+  goals: number
+  wins: number
+  losses: number
+  draws: number
+  avgPerformance: number
+  gpm: string
+  winRate: string
+  recent: RecentMatchEntry[]
+}
+
+export type CatSkills = {
+  physical: number
+  technical: number
+  tactical: number
+  psychological: number
+}
+
+function computeStats(matches: Match[], playerId: string): PlayerDetailStats {
+  let totalPerformance = 0
+  const res: PlayerDetailStats = {
+    matches: 0,
+    goals: 0,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    avgPerformance: 0,
+    gpm: '0.0',
+    winRate: '0.0',
+    recent: [],
+  }
+
+  for (const m of matches) {
+    const inA = m.teamA.find((p) => p.id === playerId)
+    const inB = m.teamB.find((p) => p.id === playerId)
+    if (!inA && !inB) continue
+
+    const me = (inA ?? inB)!
+    const team: 'A' | 'B' = inA ? 'A' : 'B'
+    const a = m.teamAScore
+    const b = m.teamBScore
+
+    res.matches++
+    res.goals += me.goals
+    totalPerformance += me.performance
+
+    let result: 'W' | 'L' | 'D'
+    if (a === b) {
+      res.draws++
+      result = 'D'
+    } else if (team === 'A') {
+      if (a > b) { res.wins++; result = 'W' }
+      else { res.losses++; result = 'L' }
+    } else {
+      if (b > a) { res.wins++; result = 'W' }
+      else { res.losses++; result = 'L' }
+    }
+
+    res.recent.push({
+      id: m.id,
+      date: m.date,
+      type: m.type,
+      team,
+      goals: me.goals,
+      performance: me.performance,
+      score: `${a} - ${b}`,
+      result,
+    })
+  }
+
+  res.recent.sort((x, y) => (y.date > x.date ? 1 : -1))
+  res.avgPerformance = res.matches > 0 ? totalPerformance / res.matches : 0
+  res.gpm = res.matches > 0 ? (res.goals / res.matches).toFixed(1) : '0.0'
+  res.winRate = res.matches > 0 ? ((res.wins / res.matches) * 100).toFixed(1) : '0.0'
+
+  return res
+}
+
+export function usePlayerDetail(playerId: string) {
+  const { players, matches, loading, refreshing, error, refresh, reload } = usePlayersData()
+
+  const player = useMemo(
+    () => players.find((p) => p.id === playerId) ?? null,
+    [players, playerId],
+  )
+
+  const stats = useMemo(() => computeStats(matches, playerId), [matches, playerId])
+
+  const streak = useMemo(
+    () => calculateCurrentStreakForPlayer(matches, playerId),
+    [matches, playerId],
+  )
+
+  const catSkills = useMemo<CatSkills>(() => {
+    if (!player) return { physical: 5, technical: 5, tactical: 5, psychological: 5 }
+    const base = player.skill ?? 5
+    return {
+      physical: Number(player.skills?.physical ?? base),
+      technical: Number(player.skills?.technical ?? base),
+      tactical: Number(player.skills?.tactical ?? base),
+      psychological: Number(player.skills?.psychological ?? base),
+    }
+  }, [player])
+
+  const overallAvg = useMemo(
+    () =>
+      (catSkills.physical + catSkills.technical + catSkills.tactical + catSkills.psychological) / 4,
+    [catSkills],
+  )
+
+  return {
+    player,
+    stats,
+    streak,
+    catSkills,
+    overallAvg,
+    loading,
+    refreshing,
+    error,
+    refresh,
+    reload,
+  }
+}

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -29,6 +29,32 @@ export async function loadPlayersAndMatches(): Promise<{
   }
 }
 
+export type PlayerPayload = {
+  name: string
+  position: string
+  skills: {
+    physical: number
+    technical: number
+    tactical: number
+    psychological: number
+  }
+  skill: number
+}
+
+export async function updatePlayerRequest(id: string, payload: PlayerPayload): Promise<void> {
+  const base = getBackendUrl()
+  const res = await fetch(`${base}/api/players/${id}`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(text || `Error al actualizar jugador (${res.status})`)
+  }
+}
+
 export async function deletePlayerRequest(id: string): Promise<void> {
   const base = getBackendUrl()
   const res = await fetch(`${base}/api/players/${id}`, {


### PR DESCRIPTION
<img width="380" height="759" alt="Captura de pantalla 2026-05-18 a la(s) 11 21 01 a  m" src="https://github.com/user-attachments/assets/2e762dc1-8b45-44ef-a96f-689a164b65ad" />

<img width="369" height="705" alt="Captura de pantalla 2026-05-18 a la(s) 11 21 20 a  m" src="https://github.com/user-attachments/assets/1368b78d-1c15-4385-ba8f-c760b3a8c609" />

---

**Implement player detail page for mobile**

Replicates the player detail screen from the web app into the mobile app (Expo Router).

**Changes:**
- `app/(tabs)/players/[id].tsx` — Full detail screen replacing the placeholder. Shows a gradient hero card (avatar, name, position, streak badge, overall skill), a stats grid (matches, goals, win rate, avg performance), skill bars (physical, technical, tactical, mental), and a recent matches list with pull-to-refresh.
- `app/(tabs)/players/edit/[id].tsx` — Edit screen for admins with name input, position chips, and skill steppers (1–10). Saves via `PATCH /api/players/:id` and reloads data on success.
- `hooks/use-player-detail.ts` — Hook that derives player stats and current streak from existing `usePlayersData`.
- `components/players/detail/` — `PlayerStatsGrid`, `PlayerSkillBars`, `RecentMatchRow` components.
- `components/players/edit/` — `PlayerEditForm` component.
- `lib/api.ts` — Added `updatePlayerRequest` (`PATCH /api/players/:id`).