### PR TITLE
feat(web): create draft in history after match team setup

### DIFF
--- a/apps/web/src/app/history/historyClient.tsx
+++ b/apps/web/src/app/history/historyClient.tsx
@@ -56,16 +56,18 @@ export default function HistoryClient({
   ]);
 
   if (open) {
+    const isDraft = open.mode === "edit" && open.match.status === "draft";
     return (
       <RecordModal
         mode={open.mode}
+        isDraft={isDraft}
         initial={open.mode === "edit" ? open.match : undefined}
         onClose={() => setOpen(false)}
         onSave={async (m) => {
           if (open.mode === "edit" && open.match) {
-            await updateMatch(open.match.id, m);
+            await updateMatch(open.match.id, { ...m, status: "completed" });
           } else {
-            await addMatch(m);
+            await addMatch({ ...m, status: "completed" });
           }
         }}
       />
@@ -151,8 +153,81 @@ export default function HistoryClient({
           )}
         </div>
       </div>
+      {/* Drafts */}
+      {storeMatches.filter((m) => m.status === "draft").length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+            📋 Borradores
+            <span className="text-sm bg-amber-100 text-amber-800 px-2 py-0.5 rounded">
+              {storeMatches.filter((m) => m.status === "draft").length}
+            </span>
+          </h2>
+          <div className="space-y-3">
+            {storeMatches
+              .filter((m) => m.status === "draft")
+              .map((m) => (
+                <div
+                  key={m.id}
+                  className="bg-white rounded-lg shadow p-4 border-l-4 border-amber-400"
+                >
+                  <div className="flex justify-between items-center">
+                    <div>
+                      {m.name && <div className="text-base font-bold mb-0.5">{m.name}</div>}
+                      <div className="flex items-center gap-2">
+                        <strong>
+                          {(() => {
+                            const [yy, mm, dd] = m.date.slice(0, 10).split("-");
+                            return `${dd}/${mm}/${yy}`;
+                          })()}
+                        </strong>
+                        <span className="inline-block bg-indigo-600 text-white text-xs px-2 py-0.5 rounded">
+                          {m.type}
+                        </span>
+                        <span className="inline-block bg-amber-100 text-amber-800 text-xs px-2 py-0.5 rounded font-semibold">
+                          BORRADOR
+                        </span>
+                      </div>
+                    </div>
+                    {isAdmin && (
+                      <div className="flex gap-2">
+                        <button
+                          className="text-sm px-3 py-1 rounded bg-amber-500 text-white hover:bg-amber-600"
+                          onClick={() => setOpen({ mode: "edit", match: m })}
+                        >
+                          Completar
+                        </button>
+                        <button
+                          className="text-red-600 hover:text-red-800 text-sm"
+                          onClick={() => handleDelete(m.id)}
+                        >
+                          Eliminar
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                    <div className="bg-gray-50 rounded p-2">
+                      <div className="font-semibold text-center mb-1 text-xs text-gray-500">Equipo A</div>
+                      {m.teamA.map((p) => (
+                        <div key={p.id} className="text-gray-700 text-xs truncate">{p.name}</div>
+                      ))}
+                    </div>
+                    <div className="bg-gray-50 rounded p-2">
+                      <div className="font-semibold text-center mb-1 text-xs text-gray-500">Equipo B</div>
+                      {m.teamB.map((p) => (
+                        <div key={p.id} className="text-gray-700 text-xs truncate">{p.name}</div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+
       <div className="space-y-4 mb-10">
         {storeMatches.filter((m) => {
+          if (m.status === "draft") return false;
           const d = m.date.slice(0, 10);
           if (fromDate && d < fromDate) return false;
           if (toDate && d > toDate) return false;
@@ -172,6 +247,7 @@ export default function HistoryClient({
         ) : (
           storeMatches
             .filter((m) => {
+              if (m.status === "draft") return false;
               const d = m.date.slice(0, 10);
               if (fromDate && d < fromDate) return false;
               if (toDate && d > toDate) return false;
@@ -326,11 +402,13 @@ export default function HistoryClient({
 
 function RecordModal({
   mode = "create",
+  isDraft = false,
   initial,
   onClose,
   onSave,
 }: {
   mode?: "create" | "edit";
+  isDraft?: boolean;
   initial?: Match;
   onClose: () => void;
   onSave: (m: Omit<Match, "id">) => void;
@@ -535,7 +613,7 @@ function RecordModal({
       <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-y-auto p-4">
         <div className="flex justify-between items-center border-b pb-2 mb-4">
           <h2 className="text-xl font-semibold">
-            Registrar Resultado del Partido
+            {isDraft ? "Completar borrador" : mode === "edit" ? "Editar partido" : "Registrar resultado"}
           </h2>
           <button className="text-black hover:text-black" onClick={onClose}>
             ✕
@@ -858,12 +936,8 @@ function RecordModal({
             onClick={handleSave}
           >
             {isLoading
-              ? mode === "edit"
-                ? "Actualizando..."
-                : "Guardando..."
-              : mode === "edit"
-                ? "Actualizar Partido"
-                : "Guardar Partido"}
+              ? isDraft ? "Completando..." : mode === "edit" ? "Actualizando..." : "Guardando..."
+              : isDraft ? "Completar partido" : mode === "edit" ? "Actualizar Partido" : "Guardar Partido"}
           </button>
         </div>
       </div>

--- a/apps/web/src/app/match/matchClient.tsx
+++ b/apps/web/src/app/match/matchClient.tsx
@@ -13,7 +13,7 @@ const MATCH_TYPES: MatchType[] = ['5v5', '6v6', '7v7', '8v8', '9v9', '10v10']
 
 export default function MatchClient({ players: initialPlayers }: { players: Player[] }) {
   const { players, hydratePlayers, resetAndReload } = usePlayerStore()
-  const { matches: allMatches, initLoad: initMatchesLoad, resetAndReload: resetMatches } = useMatchStore()
+  const { matches: allMatches, initLoad: initMatchesLoad, resetAndReload: resetMatches, saveDraft } = useMatchStore()
   const [matchType, setMatchType] = useState<MatchType>('5v5')
   const playersPerTeam = useMemo(() => parseInt(matchType.split('v')[0], 10), [matchType])
   const requiredPlayers = playersPerTeam * 2
@@ -36,6 +36,9 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   const [shirtsResponsibleId, setShirtsResponsibleId] = useState<string | null>(null)
   const [dutyPool, setDutyPool] = useState<PlayerInfo[]>([])
 
+  const [draftSaving, setDraftSaving] = useState(false)
+  const [draftSaved, setDraftSaved] = useState(false)
+
   // manual builder
   const [manualOpen, setManualOpen] = useState(false)
   const [manualA, setManualA] = useState<PlayerInfo[]>([])
@@ -44,7 +47,8 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   // search in player selection
   const [playerQuery, setPlayerQuery] = useState('')
 
-  const playedBefore = useMemo(() => buildPlayedBeforeSet(allMatches), [allMatches])
+  const completedMatches = useMemo(() => allMatches.filter(m => m.status !== 'draft'), [allMatches])
+  const playedBefore = useMemo(() => buildPlayedBeforeSet(completedMatches), [completedMatches])
 
   const selectedPlayers: PlayerInfo[] = useMemo(() => {
     const ids = new Set(selected)
@@ -148,13 +152,32 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
     return { teams: balanceTeams(pool, playersPerTeam), hadStreak: false }
   }
 
+  const handleSaveDraft = async () => {
+    if (!autoTeams) return
+    setDraftSaving(true)
+    setDraftSaved(false)
+    try {
+      const toMatchPlayer = (p: PlayerInfo) => ({ id: p.id, name: p.name, goals: 0, performance: 5 })
+      await saveDraft({
+        date: new Date().toISOString().slice(0, 10),
+        type: matchType,
+        teamA: autoTeams.teamA.players.map(toMatchPlayer),
+        teamB: autoTeams.teamB.players.map(toMatchPlayer),
+        shirtsResponsibleId: shirtsResponsibleId ?? null,
+      })
+      setDraftSaved(true)
+    } finally {
+      setDraftSaving(false)
+    }
+  }
+
   const doAuto = async () => {
     await initMatchesLoad()
     if (selected.size !== requiredPlayers) {
       alert(`Por favor, selecciona exactamente ${requiredPlayers} jugadores para ${matchType}.`)
       return
     }
-    const streaks = calculateAllCurrentStreaks(allMatches)
+    const streaks = calculateAllCurrentStreaks(completedMatches)
     const { teams, hadStreak } = buildTeams(selectedPlayers, streaks)
     setAutoTeams(teams)
     setStreakSeparated(hadStreak)
@@ -170,7 +193,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   const regenerate = async () => {
     await initMatchesLoad()
     if (!selectedPlayers.length) return
-    const streaks = calculateAllCurrentStreaks(allMatches)
+    const streaks = calculateAllCurrentStreaks(completedMatches)
     const shuffled = [...selectedPlayers].sort(() => Math.random() - 0.5)
     const { teams, hadStreak } = buildTeams(shuffled, streaks)
     setAutoTeams(teams)
@@ -386,7 +409,22 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
             <TeamCard title="Team B" team={autoTeams.teamB} color="red" winProbability={probB} />
           </div>
 
-          <div className="mt-6 border-t pt-4">
+          <div className="mt-6 border-t pt-4 flex flex-col items-center gap-3">
+            <button
+              className="w-full md:w-auto bg-amber-500 text-white px-6 py-2 rounded hover:bg-amber-600 disabled:opacity-50 font-medium"
+              onClick={handleSaveDraft}
+              disabled={draftSaving}
+            >
+              {draftSaving ? 'Guardando...' : '📋 Guardar borrador en historial'}
+            </button>
+            {draftSaved && (
+              <div className="w-full text-center text-sm bg-green-50 border border-green-200 text-green-800 rounded px-3 py-2">
+                ✓ Borrador guardado. Podés completarlo en Historial después del partido.
+              </div>
+            )}
+          </div>
+
+          <div className="mt-4 border-t pt-4">
             <div className="flex flex-col md:flex-row gap-3 md:items-center">
               <div className="text-sm">
                 <div className="font-semibold">Encargado de camisetas</div>

--- a/apps/web/src/store/useMatchStore.ts
+++ b/apps/web/src/store/useMatchStore.ts
@@ -44,6 +44,7 @@ async function fetchMatches(): Promise<Match[]> {
       teamB: teams.B,
       shirtsResponsibleId: data.shirtsResponsibleId ?? null,
       mvpId: data.mvpId ?? null,
+      status: (data.status as 'draft' | 'completed') ?? 'completed',
     }
   })
 }
@@ -53,6 +54,7 @@ type MatchStore = {
   matchesInit: 'idle' | 'loading' | 'loaded' | 'error'
   initLoad: () => Promise<void>
   addMatch: (m: Omit<Match, 'id'>) => Promise<string>
+  saveDraft: (draft: { date: string; type: string; teamA: MatchPlayer[]; teamB: MatchPlayer[]; shirtsResponsibleId?: string | null; name?: string }) => Promise<string>
   updateMatch: (id: string, m: Omit<Match, 'id'>) => Promise<void>
   deleteMatch: (id: string) => Promise<void>
   hydrateMatches: (matches: Match[]) => void
@@ -76,11 +78,41 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
   hydrateMatches: (matches) => {
     set({ matches, matchesInit: 'loaded' })
   },
+  saveDraft: async (draft) => {
+    const ref = await addDoc(collection(db, 'matches'), {
+      date: Timestamp.fromDate(new Date(draft.date)),
+      type: draft.type,
+      name: draft.name ?? null,
+      teamAScore: 0,
+      teamBScore: 0,
+      status: 'draft',
+      shirtsResponsibleId: draft.shirtsResponsibleId ?? null,
+      mvpId: null,
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    })
+    const players = [
+      ...draft.teamA.map(p => ({ ...p, team: 'A' })),
+      ...draft.teamB.map(p => ({ ...p, team: 'B' })),
+    ]
+    await Promise.all(players.map(p =>
+      addDoc(collection(db, 'matchPlayers'), {
+        matchId: ref.id,
+        playerId: p.id,
+        team: p.team,
+        goals: p.goals,
+        performance: p.performance,
+      })
+    ))
+    await get().resetAndReload()
+    return ref.id
+  },
   addMatch: async (m) => {
     const { teamA, teamB, mvpId, ...rest } = m
     const nextMvpId = mvpId ?? null
     const ref = await addDoc(collection(db, 'matches'), {
       ...rest,
+      status: 'completed',
       mvpId: nextMvpId,
       date: Timestamp.fromDate(new Date(m.date)),
       createdAt: Timestamp.now(),

--- a/packages/types/src/match.ts
+++ b/packages/types/src/match.ts
@@ -16,6 +16,7 @@ export type Match = {
   name?: string
   shirtsResponsibleId?: string | null
   mvpId?: string | null
+  status?: 'draft' | 'completed'
 }
 
 /** Minimal match shape used by streak-calculation algorithms */


### PR DESCRIPTION
## Summary

- Adds `status: 'draft' | 'completed'` to the `Match` type
- Adds `saveDraft()` to the match store — writes to Firestore with `status: 'draft'`, teams pre-filled, scores at 0
- Adds **"Guardar borrador en historial"** button (amber) in the match prep screen, visible once teams are generated
- Shows a **Borradores** section at the top of History with an amber left border and `BORRADOR` badge
- Clicking **Completar** on a draft opens the record modal pre-filled with the teams — on save, `status` becomes `completed`
- Drafts are excluded from streak/streak-separation calculations so they don't affect team balancing

## Test plan

- [ ] Generate teams in `/match`, click "Guardar borrador" → success message appears
- [ ] Go to `/history` → draft appears at the top with BORRADOR badge and team names listed
- [ ] Click "Completar" → modal opens with teams pre-filled
- [ ] Fill scores/goals/MVP, save → draft disappears from Borradores, appears in main history as completed
- [ ] Delete a draft → gone from Borradores
- [ ] Streak calculation unaffected by drafts (auto-generate still works correctly)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)