### PR TITLE
fix(mobile): login

### DIFF
--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -22,7 +22,7 @@ export default function LoginScreen() {
   const colorScheme = useColorScheme() ?? 'light'
   const theme = Colors[colorScheme]
   const router = useRouter()
-  const { signIn } = useFirebaseAuth()
+  const { signIn, register } = useFirebaseAuth()
 
   const [mode, setMode] = useState<'signin' | 'register'>('signin')
   const [email, setEmail] = useState('')
@@ -34,7 +34,11 @@ export default function LoginScreen() {
     setError(null)
     setLoading(true)
     try {
-      await signIn(email, password)
+      if (mode === 'register') {
+        await register(email, password)
+      } else {
+        await signIn(email, password)
+      }
       router.replace('/(tabs)/players')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Algo salió mal')
@@ -100,7 +104,10 @@ export default function LoginScreen() {
               value={password}
               onChangeText={setPassword}
               secureTextEntry
-              autoComplete="password"
+              autoComplete="current-password"
+              autoCorrect={false}
+              autoCapitalize="none"
+              spellCheck={false}
               placeholder="Mínimo 6 caracteres"
               placeholderTextColor={theme.icon}
               style={[styles.input, { color: theme.text, borderColor: theme.icon }]}

--- a/apps/mobile/components/navbar.tsx
+++ b/apps/mobile/components/navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { Text, Image, Pressable } from 'react-native';
 import { styles } from '@/components/navbar.styles';
 import {
@@ -10,33 +10,31 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { DrawerMenu } from '@/components/drawer-menu';
-import { ROLES, type User } from '@/constants/auth';
-
-const MOCK_USER: User = {
-  name: 'John Does',
-  email: 'eljohndoe@gmail.com',
-  role: ROLES.USER,
-  image: null,
-};
+import { useFirebaseAuth } from '@/contexts/FirebaseAuthContext';
+import type { User } from '@/constants/auth';
 
 const OPEN = { duration: 420, easing: Easing.out(Easing.cubic) };
 const CLOSE = { duration: 300, easing: Easing.in(Easing.cubic) };
 const GRADIENT = ['#7C3AED', '#F97316'] as const;
 
 export function Navbar() {
-  const [user, setUser] = useState<User | null>(null);
+  const { user: authUser, signOut } = useFirebaseAuth();
 
-  const getUser = (): Promise<User> =>
-    new Promise((resolve) => setTimeout(() => resolve(MOCK_USER), 2000));
+  const user = useMemo<User | null>(() => {
+    if (!authUser) return null;
+    return {
+      name: authUser.email.split('@')[0],
+      email: authUser.email,
+      role: authUser.role,
+      image: null,
+    };
+  }, [authUser]);
 
-  useEffect(() => {
-    getUser().then(setUser);
-  }, []);
+  const onLogout = useCallback(async () => {
+    await signOut();
+    router.replace('/login');
+  }, [signOut]);
 
-  const onLogout = () => {
-    setUser(null);
-    router.push('/login');
-  };
   const [isOpen, setIsOpen] = useState(false);
   const progress = useSharedValue(0);
   const insets = useSafeAreaInsets();

--- a/apps/mobile/contexts/FirebaseAuthContext.tsx
+++ b/apps/mobile/contexts/FirebaseAuthContext.tsx
@@ -2,10 +2,11 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 import {
   onAuthStateChanged as firebaseOnAuthStateChanged,
   signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
   signOut as firebaseSignOut,
   type User as FirebaseUser,
 } from 'firebase/auth'
-import { doc, getDoc } from 'firebase/firestore'
+import { doc, getDoc, setDoc, Timestamp } from 'firebase/firestore'
 import { auth, db } from '@/lib/firebase'
 import type { AppUser } from '@fulbito/firebase'
 
@@ -19,6 +20,7 @@ type AuthContextValue = {
   loading: boolean
   isAdmin: boolean
   signIn: (email: string, password: string) => Promise<void>
+  register: (email: string, password: string) => Promise<void>
   signOut: () => Promise<void>
 }
 
@@ -39,9 +41,19 @@ export function FirebaseAuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const signIn = async (email: string, password: string) => {
-    const cred = await signInWithEmailAndPassword(auth, email, password)
+    const cred = await signInWithEmailAndPassword(auth, email.trim(), password.trim())
     const role = await getUserRole(cred.user.uid)
     setUser({ uid: cred.user.uid, email: cred.user.email!, role })
+  }
+
+  const register = async (email: string, password: string) => {
+    const cred = await createUserWithEmailAndPassword(auth, email.trim(), password.trim())
+    await setDoc(doc(db, 'users', cred.user.uid), {
+      email: cred.user.email,
+      role: 'USER',
+      createdAt: Timestamp.now(),
+    })
+    setUser({ uid: cred.user.uid, email: cred.user.email!, role: 'USER' })
   }
 
   const signOut = async () => {
@@ -50,7 +62,7 @@ export function FirebaseAuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, isAdmin: user?.role === 'ADMIN', signIn, signOut }}>
+    <AuthContext.Provider value={{ user, loading, isAdmin: user?.role === 'ADMIN', signIn, register, signOut }}>
       {children}
     </AuthContext.Provider>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.8.1
       turbo:
         specifier: latest
-        version: 2.9.12
+        version: 2.9.14
 
   apps/mobile:
     dependencies:
@@ -2123,33 +2123,33 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@turbo/darwin-64@2.9.12':
-    resolution: {integrity: sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g==}
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.12':
-    resolution: {integrity: sha512-RUkAE404z/J8NsyrUosMcBaXT6M4bRFxTQrmkDQBLQVXaC8Jl0e9bMvYDSX0GW7Ffm2m3j9y7RXgR1foeUAM9w==}
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.12':
-    resolution: {integrity: sha512-InIUtH7cw/vqXNX1Gr7QgWfmw3ct08pV5CpfdEOR48z2u2rzdmpIuk00B/Q2xCb0PMWtKgiMQynfuphmEuUyTQ==}
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.12':
-    resolution: {integrity: sha512-lC6nD//Xh67fmJM0LKaLsg74Wry0aYrgMklpiNgCbUaMdPIOqj0A00iri3NU7Lb7pZHx8ViisgpeDKlpSgFUCA==}
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.12':
-    resolution: {integrity: sha512-conYri8VUl72JOdYnLDPYwzqbPcY5ECoHmo9FWoKznemhaAIilj4maHqs9Uar0aKfNoZIULniy+6iWaLtLO34A==}
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.12':
-    resolution: {integrity: sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ==}
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
     cpu: [arm64]
     os: [win32]
 
@@ -5048,8 +5048,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo@2.9.12:
-    resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -7770,22 +7770,22 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@turbo/darwin-64@2.9.12':
+  '@turbo/darwin-64@2.9.14':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.12':
+  '@turbo/darwin-arm64@2.9.14':
     optional: true
 
-  '@turbo/linux-64@2.9.12':
+  '@turbo/linux-64@2.9.14':
     optional: true
 
-  '@turbo/linux-arm64@2.9.12':
+  '@turbo/linux-arm64@2.9.14':
     optional: true
 
-  '@turbo/windows-64@2.9.12':
+  '@turbo/windows-64@2.9.14':
     optional: true
 
-  '@turbo/windows-arm64@2.9.12':
+  '@turbo/windows-arm64@2.9.14':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -11330,14 +11330,14 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  turbo@2.9.12:
+  turbo@2.9.14:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.12
-      '@turbo/darwin-arm64': 2.9.12
-      '@turbo/linux-64': 2.9.12
-      '@turbo/linux-arm64': 2.9.12
-      '@turbo/windows-64': 2.9.12
-      '@turbo/windows-arm64': 2.9.12
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the Firebase authentication flow on both web and mobile platforms. The web app was failing to initialize Firebase due to a missing `.env.local` file, and the mobile app had two separate issues: a broken `register` flow and an incorrect Firebase auth persistence import.

---

## Related Issues

Closes #40 
Closes #37

---

## Changes

### 🌐 Web — Firebase initialization
- Added `apps/web/.env.local` with the required `NEXT_PUBLIC_FIREBASE_*` environment variables
- Without `apiKey`, `auth` was exported as `undefined`, causing a runtime crash: `Cannot read properties of undefined (reading 'onAuthStateChanged')`

### 📱 Mobile — Firebase auth persistence
- Reverted an incorrect attempt to use `getReactNativePersistence` — this API does not exist in the `firebase/auth` v11 public bundle (it lives in the internal `@firebase/auth` React Native bundle, which is not resolved when importing `firebase/auth` through Metro)
- Restored `getAuth(app)` which works correctly

### 📱 Mobile — Register not working
- The "Create account" form was calling `signIn` instead of a non-existent `register` function, resulting in `auth/invalid-credential` for new users
- Added `register` to `FirebaseAuthContext`: creates the Firebase user via `createUserWithEmailAndPassword` and persists the user doc in Firestore with `role: 'USER'`
- `login.tsx` now correctly routes to `register` or `signIn` based on the active mode

### 📱 Mobile — Credential whitespace hardening
- `signIn` and `register` now call `.trim()` on both email and password before passing them to Firebase — iOS keyboards can silently append trailing spaces, causing `auth/invalid-credential` on otherwise valid credentials
- Password `TextInput` now sets `autoCorrect={false}`, `autoCapitalize="none"` and `spellCheck={false}` to prevent the keyboard from mutating the password value

### 📱 Mobile — Navbar showing hardcoded "John Doe" after login
- `Navbar` had a `MOCK_USER` constant hardcoded with `name: 'John Does'` and a fake `getUser()` that always resolved the mock after a 2-second timeout — Firebase Auth was never consulted
- Replaced with `useFirebaseAuth()` so the navbar now reads the real session from the `FirebaseAuthProvider` context
- The displayed name is derived from the user's email (part before `@`) since `AppUser` does not store a display name
- Fixed `onLogout`: previously only navigated to `/login` without calling Firebase `signOut()` — now calls `signOut()` from the context before redirecting

---

## QA Steps

### Web
- [ ] Run `pnpm --filter @fulbito/web dev`
- [ ] Navigate to `/login`
- [ ] Sign in with email + password — should redirect to the dashboard
- [ ] Sign in with Google — should redirect to the dashboard
- [ ] Sign out — should redirect back to `/login`

### Mobile
- [ ] Run `pnpm --filter @fulbito/mobile start --clear`
- [ ] Open in Expo Go
- [ ] **Login tab** — enter existing credentials → should land on the players screen
- [ ] **Register tab** — enter a new email + password → should create the account and land on the players screen
- [ ] Verify the new user doc exists in Firestore under `users/{uid}` with `role: "USER"`
- [ ] Test with leading/trailing spaces in the email field — should still authenticate correctly
- [ ] After login, navbar should show the user's email prefix (not "John Doe") and the avatar should open the drawer
- [ ] Tap "Cerrar sesión" in the drawer — should sign out from Firebase and redirect to `/login`

---

## Screenshots

> ⚠️ Add screenshots here before merging

| Web Login | Mobile Login | Mobile Register |
|-----------|-------------|-----------------|
| _pending_ | _pending_ | _pending_ |

---

## Notes

- `.env.local` is git-ignored by Next.js convention and must be set up locally by each developer. A `.env.example` file should be added to document the required variables (tracked in #71).
- Firebase v11 removed the public export of `getReactNativePersistence` from the `firebase/auth` entry point. Proper AsyncStorage-based persistence for React Native requires either downgrading to v10 or using a custom persistence adapter — deferred to a separate task.
