### PR TITLE
Feat: Get shirtDutiesCount from matches

### DIFF
--- a/apps/mobile/components/match/matchForm.tsx
+++ b/apps/mobile/components/match/matchForm.tsx
@@ -56,7 +56,7 @@ export function MatchForm({
   const pool = usePool(players, initial)
   const teams = useTeams(initial)
   const scores = useScores(initial)
-  const shirts = useShirts(players, allMatches, teams.teamA, teams.teamB, initial)
+  const shirts = useShirts(allMatches, teams.teamA, teams.teamB, initial)
 
   // ── Derived ─────────────────────────────────────────────────────────────────
   const teamStats = useMemo(
@@ -204,6 +204,7 @@ export function MatchForm({
         onChange={shirts.setShirtsResponsibleId}
         teamPlayers={shirts.teamPlayers}
         playedBefore={shirts.playedBefore}
+        dutiesById={shirts.dutiesById}
       />
 
       <FormActions

--- a/apps/mobile/components/match/matchForm/shirtsSection.tsx
+++ b/apps/mobile/components/match/matchForm/shirtsSection.tsx
@@ -15,6 +15,7 @@ type Props = {
   onChange: (id: string | null) => void
   teamPlayers: RecordingPlayer[]
   playedBefore: Set<string>
+  dutiesById: Map<string, number>
 }
 
 export function ShirtsSection({
@@ -23,6 +24,7 @@ export function ShirtsSection({
   onChange,
   teamPlayers,
   playedBefore,
+  dutiesById,
 }: Props) {
   const { colors, radii } = useAppTheme()
   const [open, setOpen] = useState(false)
@@ -33,15 +35,15 @@ export function ShirtsSection({
 
   const eligible = teamPlayers.some((p) => playedBefore.has(p.id))
   const options = [
-    { id: '', name: 'Sin seleccionar', disabled: false },
+    { id: '', name: 'Sin seleccionar', disabled: false, duties: 0 },
     ...teamPlayers.map((p) => {
-      const playerData = players.find((pp) => pp.id === p.id)
+      const duties = dutiesById.get(p.id) ?? 0
       const isNew = eligible && !playedBefore.has(p.id)
       return {
         id: p.id,
-        name: `${p.name} (#${playerData?.shirtDutiesCount ?? 0})${isNew ? ' — nuevo' : ''}`,
+        name: `${p.name} (#${duties})${isNew ? ' — nuevo' : ''}`,
         disabled: isNew,
-        duties: playerData?.shirtDutiesCount ?? 0,
+        duties,
       }
     }),
   ]

--- a/apps/mobile/components/match/matchForm/useShirts.ts
+++ b/apps/mobile/components/match/matchForm/useShirts.ts
@@ -1,8 +1,9 @@
-import type { Match, Player } from '@fulbito/types'
+import type { Match } from '@fulbito/types'
 import {
   buildPlayedBeforeSet,
   computeLeastAssignedPoolIds,
   getEligiblePlayerIds,
+  getShirtDutiesByPlayerId,
 } from '@fulbito/utils'
 import { useMemo, useState } from 'react'
 
@@ -16,6 +17,8 @@ export type ShirtsState = {
   teamPlayers: RecordingPlayer[]
   /** IDs candidatos para asignación automática */
   dutyPoolIds: string[]
+  /** Conteo derivado de cuántas veces cada jugador se llevó las camisetas */
+  dutiesById: Map<string, number>
 }
 
 export function useShirts(
@@ -29,14 +32,15 @@ export function useShirts(
   )
 
   const playedBefore = useMemo(() => buildPlayedBeforeSet(allMatches), [allMatches])
+  const dutiesById = useMemo(() => getShirtDutiesByPlayerId(allMatches), [allMatches])
 
   const { teamPlayers, dutyPoolIds } = useMemo(() => {
     const all = [...teamA, ...teamB]
     const teamIds = all.map((p) => p.id)
     const eligibleIds = getEligiblePlayerIds(teamIds, playedBefore)
-    const { poolIds } = computeLeastAssignedPoolIds(eligibleIds, players)
+    const { poolIds } = computeLeastAssignedPoolIds(eligibleIds, dutiesById)
     return { teamPlayers: all, dutyPoolIds: poolIds }
-  }, [teamA, teamB, players, playedBefore])
+  }, [teamA, teamB, dutiesById, playedBefore])
 
   return {
     shirtsResponsibleId,
@@ -44,6 +48,7 @@ export function useShirts(
     playedBefore,
     teamPlayers,
     dutyPoolIds,
+    dutiesById,
   }
 }
 

--- a/apps/mobile/components/match/matchForm/useShirts.ts
+++ b/apps/mobile/components/match/matchForm/useShirts.ts
@@ -19,7 +19,6 @@ export type ShirtsState = {
 }
 
 export function useShirts(
-  players: Player[],
   allMatches: Match[],
   teamA: RecordingPlayer[],
   teamB: RecordingPlayer[],

--- a/apps/mobile/hooks/use-matches-data.ts
+++ b/apps/mobile/hooks/use-matches-data.ts
@@ -10,7 +10,6 @@ import {
   query,
   orderBy,
   Timestamp,
-  increment,
   type DocumentData,
 } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
@@ -107,25 +106,20 @@ export function useMatchesData(): MatchesDataState {
 
   const deleteMatch = useCallback(
     async (id: string) => {
-      const prevMvpId = matches.find(x => x.id === id)?.mvpId ?? null
       await deleteDoc(doc(db, 'matches', id))
       const mpSnap = await getDocs(collection(db, 'matchPlayers'))
       await Promise.all(mpSnap.docs.filter(d => d.data().matchId === id).map(d => deleteDoc(d.ref)))
-      if (prevMvpId) {
-        await updateDoc(doc(db, 'players', prevMvpId), { mvpCount: increment(-1) })
-      }
       await reload()
     },
-    [matches, reload],
+    [reload],
   )
 
   const addMatch = useCallback(
     async (m: Omit<Match, 'id'>) => {
       const { teamA, teamB, mvpId, ...rest } = m
-      const nextMvpId = mvpId ?? null
       const ref = await addDoc(collection(db, 'matches'), {
         ...rest,
-        mvpId: nextMvpId,
+        mvpId: mvpId ?? null,
         date: Timestamp.fromDate(new Date(m.date)),
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now(),
@@ -145,9 +139,6 @@ export function useMatchesData(): MatchesDataState {
           }),
         ),
       )
-      if (nextMvpId) {
-        await updateDoc(doc(db, 'players', nextMvpId), { mvpCount: increment(1) })
-      }
       await reload()
     },
     [reload],
@@ -156,11 +147,9 @@ export function useMatchesData(): MatchesDataState {
   const updateMatch = useCallback(
     async (id: string, m: Omit<Match, 'id'>) => {
       const { teamA, teamB, mvpId, ...rest } = m
-      const prevMvpId = matches.find(x => x.id === id)?.mvpId ?? null
-      const nextMvpId = mvpId ?? null
       await updateDoc(doc(db, 'matches', id), {
         ...rest,
-        mvpId: nextMvpId,
+        mvpId: mvpId ?? null,
         date: Timestamp.fromDate(new Date(m.date)),
         updatedAt: Timestamp.now(),
       })
@@ -182,15 +171,9 @@ export function useMatchesData(): MatchesDataState {
           }),
         ),
       )
-      if (prevMvpId !== nextMvpId) {
-        const ops: Promise<void>[] = []
-        if (prevMvpId) ops.push(updateDoc(doc(db, 'players', prevMvpId), { mvpCount: increment(-1) }))
-        if (nextMvpId) ops.push(updateDoc(doc(db, 'players', nextMvpId), { mvpCount: increment(1) }))
-        await Promise.all(ops)
-      }
       await reload()
     },
-    [matches, reload],
+    [reload],
   )
 
   useEffect(() => {

--- a/apps/mobile/hooks/use-player-statistics.ts
+++ b/apps/mobile/hooks/use-player-statistics.ts
@@ -1,4 +1,5 @@
 import type { Match, Player } from '@fulbito/types'
+import { getShirtDutiesByPlayerId } from '@fulbito/utils'
 import { useMemo, useState } from 'react'
 
 export type SortTabKey = 'goals' | 'matches' | 'totalPerformance' | 'winRate'
@@ -21,7 +22,7 @@ export function usePlayerStatistics(players: Player[], matches: Match[]) {
 
   const stats = useMemo<PlayerStatRow[]>(() => {
     const map: Record<string, PlayerStatRow> = {}
-    const shirtCountById = new Map(players.map((p) => [p.id, p.shirtDutiesCount ?? 0]))
+    const shirtCountById = getShirtDutiesByPlayerId(matches)
     const photoById = new Map(players.map((p) => [p.id, p.photoUrl ?? undefined]))
 
     for (const m of matches) {

--- a/apps/mobile/hooks/use-players-data.ts
+++ b/apps/mobile/hooks/use-players-data.ts
@@ -15,7 +15,6 @@ function docToPlayer(id: string, data: Record<string, any>): Player {
     skill: data.skill ?? null,
     skills: data.skills,
     photoUrl: data.photoUrl,
-    shirtDutiesCount: data.shirtDutiesCount ?? 0,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),
   }

--- a/apps/mobile/lib/shape.ts
+++ b/apps/mobile/lib/shape.ts
@@ -7,7 +7,6 @@ type RawPlayer = {
   skill: number | null
   skills?: unknown
   photoUrl?: string | null
-  shirtDutiesCount?: number
   createdAt: Date | string
   updatedAt: Date | string
 }
@@ -20,7 +19,6 @@ export function shapeStorePlayers(players: RawPlayer[]): Player[] {
     skill: p.skill ?? null,
     skills: p.skills as Player['skills'],
     photoUrl: p.photoUrl ?? undefined,
-    shirtDutiesCount: p.shirtDutiesCount ?? 0,
     createdAt: p.createdAt instanceof Date ? p.createdAt : new Date(p.createdAt),
     updatedAt: p.updatedAt instanceof Date ? p.updatedAt : new Date(p.updatedAt),
   }))

--- a/apps/web/scripts/seed-firebase.mjs
+++ b/apps/web/scripts/seed-firebase.mjs
@@ -112,7 +112,6 @@ async function main() {
       skill: p.skill,
       skills: p.skills,
       photoUrl,
-      shirtDutiesCount: 0,
       createdAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
     })

--- a/apps/web/src/app/history/historyClient.tsx
+++ b/apps/web/src/app/history/historyClient.tsx
@@ -8,6 +8,7 @@ import {
   buildPlayedBeforeSet,
   getEligiblePlayerIds,
   computeLeastAssignedPoolIds,
+  getShirtDutiesByPlayerId,
 } from "@/lib/shirtDuty";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { DropColumn, DraggableItem } from "@/components/DragAndDrop";
@@ -341,6 +342,10 @@ function RecordModal({
     () => buildPlayedBeforeSet(allMatches),
     [allMatches],
   );
+  const dutiesById = useMemo(
+    () => getShirtDutiesByPlayerId(allMatches),
+    [allMatches],
+  );
   const [matchDate, setMatchDate] = useState<string>(
     initial?.date?.slice(0, 10) || new Date().toISOString().slice(0, 10),
   );
@@ -387,11 +392,11 @@ function RecordModal({
     const consideredIds = getEligiblePlayerIds(teamIds, playedBefore);
     const { poolIds, min } = computeLeastAssignedPoolIds(
       consideredIds,
-      players,
+      dutiesById,
     );
     const pool = all.filter((p) => poolIds.includes(p.id));
     return { pool, min };
-  }, [teamA, teamB, players, playedBefore]);
+  }, [teamA, teamB, dutiesById, playedBefore]);
   const [shirtsResponsibleId, setShirtsResponsibleId] = useState<string | null>(
     initial?.shirtsResponsibleId ?? null,
   );
@@ -778,10 +783,7 @@ function RecordModal({
                       value={p.id}
                       disabled={eligibleExists && !playedBefore.has(p.id)}
                     >
-                      {p.name} (#
-                      {players.find((pp) => pp.id === p.id)?.shirtDutiesCount ??
-                        0}
-                      )
+                      {p.name} (#{dutiesById.get(p.id) ?? 0})
                       {eligibleExists && !playedBefore.has(p.id)
                         ? " — nuevo"
                         : ""}

--- a/apps/web/src/app/match/matchClient.tsx
+++ b/apps/web/src/app/match/matchClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { usePlayerStore , Player} from '@/store/usePlayerStore'
 import { useMatchStore } from '@/store/useMatchStore'
-import { buildPlayedBeforeSet, getEligiblePlayerIds, computeLeastAssignedPoolIds } from '@/lib/shirtDuty'
+import { buildPlayedBeforeSet, getEligiblePlayerIds, computeLeastAssignedPoolIds, getShirtDutiesByPlayerId } from '@/lib/shirtDuty'
 import { balanceRemainingPlayers, balanceTeams, PlayerInfo, TeamResult } from '@/lib/teamUtils'
 import { calculateAllCurrentStreaks } from '@/lib/playerStats'
 import { DropColumn, DraggableItem } from '@/components/DragAndDrop'
@@ -45,6 +45,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   const [playerQuery, setPlayerQuery] = useState('')
 
   const playedBefore = useMemo(() => buildPlayedBeforeSet(allMatches), [allMatches])
+  const dutiesById = useMemo(() => getShirtDutiesByPlayerId(allMatches), [allMatches])
 
   const selectedPlayers: PlayerInfo[] = useMemo(() => {
     const ids = new Set(selected)
@@ -160,7 +161,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
     setStreakSeparated(hadStreak)
     const teamIds = [...teams.teamA.players, ...teams.teamB.players].map(p => p.id)
     const consideredIds = getEligiblePlayerIds(teamIds, playedBefore)
-    const { poolIds } = computeLeastAssignedPoolIds(consideredIds, players)
+    const { poolIds } = computeLeastAssignedPoolIds(consideredIds, dutiesById)
     const poolObjs = [...teams.teamA.players, ...teams.teamB.players].filter(p => poolIds.includes(p.id))
     setDutyPool(poolObjs)
     setShirtsResponsibleId(poolIds.length ? poolIds[Math.floor(Math.random() * poolIds.length)] : null)
@@ -177,7 +178,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
     setStreakSeparated(hadStreak)
     const teamIds = [...teams.teamA.players, ...teams.teamB.players].map(p => p.id)
     const consideredIds = getEligiblePlayerIds(teamIds, playedBefore)
-    const { poolIds } = computeLeastAssignedPoolIds(consideredIds, players)
+    const { poolIds } = computeLeastAssignedPoolIds(consideredIds, dutiesById)
     const poolObjs = [...teams.teamA.players, ...teams.teamB.players].filter(p => poolIds.includes(p.id))
     setDutyPool(poolObjs)
     setShirtsResponsibleId(poolIds.length ? poolIds[Math.floor(Math.random() * poolIds.length)] : null)
@@ -202,7 +203,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
       setAutoTeams(teams)
       const teamIds = [...teams.teamA.players, ...teams.teamB.players].map(p => p.id)
       const consideredIds = getEligiblePlayerIds(teamIds, playedBefore)
-      const { poolIds } = computeLeastAssignedPoolIds(consideredIds, players)
+      const { poolIds } = computeLeastAssignedPoolIds(consideredIds, dutiesById)
       const poolObjs = [...teams.teamA.players, ...teams.teamB.players].filter(p => poolIds.includes(p.id))
       setDutyPool(poolObjs)
       setShirtsResponsibleId(poolIds.length ? poolIds[Math.floor(Math.random() * poolIds.length)] : null)
@@ -211,7 +212,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
       setAutoTeams(teams)
       const teamIds = [...teams.teamA.players, ...teams.teamB.players].map(p => p.id)
       const consideredIds = getEligiblePlayerIds(teamIds, playedBefore)
-      const { poolIds } = computeLeastAssignedPoolIds(consideredIds, players)
+      const { poolIds } = computeLeastAssignedPoolIds(consideredIds, dutiesById)
       const poolObjs = [...teams.teamA.players, ...teams.teamB.players].filter(p => poolIds.includes(p.id))
       setDutyPool(poolObjs)
       setShirtsResponsibleId(poolIds.length ? poolIds[Math.floor(Math.random() * poolIds.length)] : null)
@@ -415,7 +416,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
                     const eligibleExists = current.some(p => played.has(p.id))
                     return current.map(p => (
                       <option key={p.id} value={p.id} disabled={eligibleExists && !played.has(p.id)}>
-                        {p.name} (#{(players.find(pp => pp.id === p.id)?.shirtDutiesCount ?? 0)}){eligibleExists && !played.has(p.id) ? ' — nuevo' : ''}
+                        {p.name} (#{dutiesById.get(p.id) ?? 0}){eligibleExists && !played.has(p.id) ? ' — nuevo' : ''}
                       </option>
                     ))
                   })()}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -14,6 +14,7 @@ import PlayerCard from '@/components/PlayerCard'
 import { useRef } from 'react'
 import { calculateCurrentStreakForPlayer } from "@/lib/playerStats";
 import { getShirtDutiesByPlayerId } from "@/lib/shirtDuty";
+import { getMvpCountsByPlayerId } from "@fulbito/utils";
 import { useFirebaseAuth } from '@/contexts/FirebaseAuthContext'
 
 export default function PlayerDetailPage() {
@@ -142,6 +143,11 @@ export default function PlayerDetailPage() {
 
   const shirtDutiesCount = useMemo(
     () => getShirtDutiesByPlayerId(matches).get(id as string) ?? 0,
+    [matches, id]
+  );
+
+  const mvpCount = useMemo(
+    () => getMvpCountsByPlayerId(matches).get(id as string) ?? 0,
     [matches, id]
   );
 
@@ -440,7 +446,7 @@ export default function PlayerDetailPage() {
             <span aria-hidden="true">🏆</span>
             MVP del partido
           </div>
-          <div className="text-2xl font-semibold">{player.mvpCount ?? 0} Veces</div>
+          <div className="text-2xl font-semibold">{mvpCount} Veces</div>
         </div>
       </div>
 

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -13,6 +13,7 @@ import RadarChart from '@/components/RadarChart'
 import PlayerCard from '@/components/PlayerCard'
 import { useRef } from 'react'
 import { calculateCurrentStreakForPlayer } from "@/lib/playerStats";
+import { getShirtDutiesByPlayerId } from "@/lib/shirtDuty";
 import { useFirebaseAuth } from '@/contexts/FirebaseAuthContext'
 
 export default function PlayerDetailPage() {
@@ -136,6 +137,11 @@ export default function PlayerDetailPage() {
 
   const currentStreak = useMemo(
     () => calculateCurrentStreakForPlayer(matches, id as string),
+    [matches, id]
+  );
+
+  const shirtDutiesCount = useMemo(
+    () => getShirtDutiesByPlayerId(matches).get(id as string) ?? 0,
     [matches, id]
   );
 
@@ -427,7 +433,7 @@ export default function PlayerDetailPage() {
         </div>
         <div className="bg-white rounded-lg shadow p-4 text-center">
           <div className="text-sm text-gray-700">Llevo las Camisetas</div>
-          <div className="text-2xl font-semibold">{player.shirtDutiesCount ?? 0} Veces</div>
+          <div className="text-2xl font-semibold">{shirtDutiesCount} Veces</div>
         </div>
         <div className="bg-white rounded-lg shadow p-4 text-center">
           <div className="text-sm text-gray-700 flex items-center justify-center gap-1.5">

--- a/apps/web/src/app/statistics/statisticsClient.tsx
+++ b/apps/web/src/app/statistics/statisticsClient.tsx
@@ -6,6 +6,7 @@ import type { Match, Player } from "@fulbito/types";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { useMatchStore } from "@/store/useMatchStore";
 import { getShirtDutiesByPlayerId } from "@/lib/shirtDuty";
+import { getMvpCountsByPlayerId } from "@fulbito/utils";
 
 export default function StatisticsClient({
   players: propsPlayers,
@@ -74,9 +75,7 @@ export default function StatisticsClient({
       }
     > = {};
     const shirtCountById = getShirtDutiesByPlayerId(matches);
-    const mvpCountById = new Map(
-      players.map((p) => [p.id, p.mvpCount ?? 0]),
-    );
+    const mvpCountById = getMvpCountsByPlayerId(matches);
     for (const m of matches) {
       const process =
         (team: "A" | "B") =>

--- a/apps/web/src/app/statistics/statisticsClient.tsx
+++ b/apps/web/src/app/statistics/statisticsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { Match, Player } from "@fulbito/types";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { useMatchStore } from "@/store/useMatchStore";
+import { getShirtDutiesByPlayerId } from "@/lib/shirtDuty";
 
 export default function StatisticsClient({
   players: propsPlayers,
@@ -72,9 +73,7 @@ export default function StatisticsClient({
         mvps: number;
       }
     > = {};
-    const shirtCountById = new Map(
-      players.map((p) => [p.id, p.shirtDutiesCount ?? 0]),
-    );
+    const shirtCountById = getShirtDutiesByPlayerId(matches);
     const mvpCountById = new Map(
       players.map((p) => [p.id, p.mvpCount ?? 0]),
     );

--- a/apps/web/src/lib/shirtDuty.ts
+++ b/apps/web/src/lib/shirtDuty.ts
@@ -2,4 +2,5 @@ export {
   buildPlayedBeforeSet,
   getEligiblePlayerIds,
   computeLeastAssignedPoolIds,
+  getShirtDutiesByPlayerId,
 } from '@fulbito/utils'

--- a/apps/web/src/store/useMatchStore.ts
+++ b/apps/web/src/store/useMatchStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import type { Match, MatchPlayer } from '@fulbito/types'
 import {
   collection, doc, getDocs, addDoc, updateDoc, deleteDoc,
-  query, orderBy, Timestamp, increment, type DocumentData,
+  query, orderBy, Timestamp, type DocumentData,
 } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 
@@ -78,10 +78,9 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
   },
   addMatch: async (m) => {
     const { teamA, teamB, mvpId, ...rest } = m
-    const nextMvpId = mvpId ?? null
     const ref = await addDoc(collection(db, 'matches'), {
       ...rest,
-      mvpId: nextMvpId,
+      mvpId: mvpId ?? null,
       date: Timestamp.fromDate(new Date(m.date)),
       createdAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
@@ -99,19 +98,14 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
         performance: p.performance,
       })
     ))
-    if (nextMvpId) {
-      await updateDoc(doc(db, 'players', nextMvpId), { mvpCount: increment(1) })
-    }
     await get().resetAndReload()
     return ref.id
   },
   updateMatch: async (id, m) => {
     const { teamA, teamB, mvpId, ...rest } = m
-    const prevMvpId = get().matches.find(x => x.id === id)?.mvpId ?? null
-    const nextMvpId = mvpId ?? null
     await updateDoc(doc(db, 'matches', id), {
       ...rest,
-      mvpId: nextMvpId,
+      mvpId: mvpId ?? null,
       date: Timestamp.fromDate(new Date(m.date)),
       updatedAt: Timestamp.now(),
     })
@@ -132,23 +126,13 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
         performance: p.performance,
       })
     ))
-    if (prevMvpId !== nextMvpId) {
-      const ops: Promise<void>[] = []
-      if (prevMvpId) ops.push(updateDoc(doc(db, 'players', prevMvpId), { mvpCount: increment(-1) }))
-      if (nextMvpId) ops.push(updateDoc(doc(db, 'players', nextMvpId), { mvpCount: increment(1) }))
-      await Promise.all(ops)
-    }
     await get().resetAndReload()
   },
   deleteMatch: async (id) => {
-    const prevMvpId = get().matches.find(x => x.id === id)?.mvpId ?? null
     await deleteDoc(doc(db, 'matches', id))
     // Clean up associated matchPlayers
     const mpSnap = await getDocs(collection(db, 'matchPlayers'))
     await Promise.all(mpSnap.docs.filter(d => d.data().matchId === id).map(d => deleteDoc(d.ref)))
-    if (prevMvpId) {
-      await updateDoc(doc(db, 'players', prevMvpId), { mvpCount: increment(-1) })
-    }
     await get().resetAndReload()
   },
   resetAndReload: async () => {

--- a/apps/web/src/store/usePlayerStore.ts
+++ b/apps/web/src/store/usePlayerStore.ts
@@ -16,7 +16,6 @@ function docToPlayer(id: string, data: DocumentData): Player {
     skill: data.skill ?? null,
     skills: data.skills,
     photoUrl: data.photoUrl,
-    shirtDutiesCount: data.shirtDutiesCount ?? 0,
     mvpCount: data.mvpCount ?? 0,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),

--- a/apps/web/src/store/usePlayerStore.ts
+++ b/apps/web/src/store/usePlayerStore.ts
@@ -16,7 +16,6 @@ function docToPlayer(id: string, data: DocumentData): Player {
     skill: data.skill ?? null,
     skills: data.skills,
     photoUrl: data.photoUrl,
-    mvpCount: data.mvpCount ?? 0,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),
   }

--- a/packages/firebase/src/matches.ts
+++ b/packages/firebase/src/matches.ts
@@ -3,8 +3,7 @@ import {
   getDocs, getDoc, addDoc, updateDoc, deleteDoc,
   query, orderBy, Timestamp,
 } from 'firebase/firestore'
-import type { Match, MatchPlayer } from '@fulbito/types'
-import { incrementShirtDuty } from './players'
+import type { Match } from '@fulbito/types'
 
 function docToMatch(id: string, data: Record<string, any>): Match {
   return {
@@ -46,37 +45,17 @@ export async function createMatch(data: Omit<Match, 'id'>): Promise<string> {
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
   })
-  if (data.shirtsResponsibleId) {
-    await incrementShirtDuty(data.shirtsResponsibleId, 1)
-  }
   return ref.id
 }
 
 export async function updateMatch(id: string, data: Partial<Omit<Match, 'id'>>): Promise<void> {
   const db = getFirestore()
-  const existing = await getMatch(id)
-
   const update: Record<string, any> = { ...data, updatedAt: Timestamp.now() }
   if (data.date) update.date = Timestamp.fromDate(new Date(data.date))
-
   await updateDoc(doc(db, 'matches', id), update)
-
-  // Adjust shirt duty counts if responsible player changed
-  if (existing && 'shirtsResponsibleId' in data) {
-    const oldId = existing.shirtsResponsibleId
-    const newId = data.shirtsResponsibleId
-    if (oldId !== newId) {
-      if (oldId) await incrementShirtDuty(oldId, -1)
-      if (newId) await incrementShirtDuty(newId, 1)
-    }
-  }
 }
 
 export async function deleteMatch(id: string): Promise<void> {
   const db = getFirestore()
-  const match = await getMatch(id)
   await deleteDoc(doc(db, 'matches', id))
-  if (match?.shirtsResponsibleId) {
-    await incrementShirtDuty(match.shirtsResponsibleId, -1)
-  }
 }

--- a/packages/firebase/src/players.ts
+++ b/packages/firebase/src/players.ts
@@ -13,7 +13,6 @@ function docToPlayer(id: string, data: Record<string, any>): Player {
     skill: data.skill ?? null,
     skills: data.skills,
     photoUrl: data.photoUrl,
-    shirtDutiesCount: data.shirtDutiesCount ?? 0,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),
   }
@@ -39,7 +38,6 @@ export async function createPlayer(data: Omit<Player, 'id' | 'createdAt' | 'upda
     skill: data.skill ?? null,
     skills: data.skills ?? null,
     photoUrl: data.photoUrl ?? null,
-    shirtDutiesCount: data.shirtDutiesCount ?? 0,
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
   })
@@ -54,12 +52,4 @@ export async function updatePlayer(id: string, data: Partial<Omit<Player, 'id' |
 export async function deletePlayer(id: string): Promise<void> {
   const db = getFirestore()
   await deleteDoc(doc(db, 'players', id))
-}
-
-export async function incrementShirtDuty(playerId: string, delta: 1 | -1): Promise<void> {
-  const db = getFirestore()
-  const player = await getPlayer(playerId)
-  if (!player) return
-  const newCount = Math.max(0, (player.shirtDutiesCount ?? 0) + delta)
-  await updateDoc(doc(db, 'players', playerId), { shirtDutiesCount: newCount, updatedAt: Timestamp.now() })
 }

--- a/packages/types/src/player.ts
+++ b/packages/types/src/player.ts
@@ -14,7 +14,6 @@ export type Player = {
   position: string
   skills?: Skills
   photoUrl?: string
-  shirtDutiesCount?: number
   mvpCount?: number
   createdAt: Date
   updatedAt: Date

--- a/packages/types/src/player.ts
+++ b/packages/types/src/player.ts
@@ -14,7 +14,6 @@ export type Player = {
   position: string
   skills?: Skills
   photoUrl?: string
-  mvpCount?: number
   createdAt: Date
   updatedAt: Date
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from './teamUtils'
 export * from './playerStats'
 export * from './shirtDuty'
+export * from './mvp'

--- a/packages/utils/src/mvp.ts
+++ b/packages/utils/src/mvp.ts
@@ -1,0 +1,11 @@
+import type { Match } from '@fulbito/types'
+
+export function getMvpCountsByPlayerId(matches: Match[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const m of matches) {
+    if (m.mvpId) {
+      counts.set(m.mvpId, (counts.get(m.mvpId) ?? 0) + 1)
+    }
+  }
+  return counts
+}

--- a/packages/utils/src/shirtDuty.ts
+++ b/packages/utils/src/shirtDuty.ts
@@ -1,4 +1,14 @@
-import type { Player, Match } from '@fulbito/types'
+import type { Match } from '@fulbito/types'
+
+export function getShirtDutiesByPlayerId(matches: Match[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const m of matches) {
+    if (m.shirtsResponsibleId) {
+      counts.set(m.shirtsResponsibleId, (counts.get(m.shirtsResponsibleId) ?? 0) + 1)
+    }
+  }
+  return counts
+}
 
 export function buildPlayedBeforeSet(matches: Match[]): Set<string> {
   const played = new Set<string>()
@@ -19,14 +29,13 @@ export function getEligiblePlayerIds(
 
 export function computeLeastAssignedPoolIds(
   consideredIds: string[],
-  allPlayers: Player[]
+  dutiesById: Map<string, number>,
 ): { poolIds: string[]; min: number } {
-  const counts = new Map<string, number>(allPlayers.map(p => [p.id, p.shirtDutiesCount ?? 0]))
   let min = Infinity
   for (const id of consideredIds) {
-    const c = counts.get(id) ?? 0
+    const c = dutiesById.get(id) ?? 0
     if (c < min) min = c
   }
-  const poolIds = consideredIds.filter(id => (counts.get(id) ?? 0) === min)
+  const poolIds = consideredIds.filter(id => (dutiesById.get(id) ?? 0) === min)
   return { poolIds, min }
 }


### PR DESCRIPTION
⏺ Fixes the shirt duty counter bug where the count never updated when a match was created
  (Error on Shirts counter #75), and applies the same treatment to MVP counts. Root cause:
  web/mobile bypass the @fulbito/firebase package and write to Firestore directly, so the
  existing incrementShirtDuty helper was never invoked. MVP counts had the mirror-image
  problem — the web/mobile write paths did call `mvpCount: increment(±1)` on the player doc,
  but that logic was duplicated across three sites and trivially driftable.

  Instead of fixing the increment in the duplicated write paths, removes the persisted
  shirtDutiesCount and mvpCount fields entirely and derives them on read from
  `match.shirtsResponsibleId` and `match.mvpId` respectively. Neither counter can drift out
  of sync anymore.

  Why this approach
  The previous approach required every write path (web store, mobile hook, shared package)
  to remember to increment/decrement. That's how the bug snuck in.
  Deriving from match history makes both counts pure functions of the source data —
  impossible to desync. Also removes the need to keep three duplicated write implementations
  in sync, which was the deeper architectural problem.

  Result:
  - New `getShirtDutiesByPlayerId(matches)` and `getMvpCountsByPlayerId(matches)` in
    `@fulbito/utils` — single source of truth, called from every consumer.
  - `Player.shirtDutiesCount` and `Player.mvpCount` removed from the shared type, store
    hydrators, Firestore reader/writers, and seed script.
  - `incrementShirtDuty` deleted from `@fulbito/firebase`; the increment/decrement blocks
    in `useMatchStore`, mobile `use-matches-data`, and `packages/firebase/src/matches.ts`
    are gone.
  - `computeLeastAssignedPoolIds` now takes a `Map<id, count>` instead of `Player[]`,
    decoupling it from the Player shape.
  - All consumers updated: web (`historyClient`, `matchClient`, `statisticsClient`,
    `players/[id]/page`) and mobile (`useShirts`, `usePlayerStatistics`, `shirtsSection`).
  - Lint + web build clean. Existing Firestore docs keep their stale `shirtDutiesCount` /
    `mvpCount` fields — harmless, just ignored on read.
  
<img width="1278" height="540" alt="image" src="https://github.com/user-attachments/assets/1dfb388a-69fb-4dd6-b411-c4e3f564d4f8" />
