### PR TITLE
feat: add goalkeeper skill and match goalkeeper selection

### DIFF
--- a/apps/mobile/app/(tabs)/players/[id].tsx
+++ b/apps/mobile/app/(tabs)/players/[id].tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import MaterialIcons from '@expo/vector-icons/MaterialIcons'
+import { getGoalkeeping } from '@fulbito/utils'
 
 import { PlayerAvatar } from '@/components/players/player-avatar'
 import { StreakBadge } from '@/components/players/streak-badge'
@@ -137,7 +138,7 @@ export default function PlayerDetailScreen() {
               { backgroundColor: colors.surface, borderColor: colors.border },
               shadows.card(isDark),
             ]}>
-            <PlayerSkillBars skills={catSkills} />
+            <PlayerSkillBars skills={catSkills} goalkeeping={getGoalkeeping(player)} />
           </View>
 
           {/* ── Últimos partidos ─────────────────────────────── */}

--- a/apps/mobile/app/(tabs)/players/edit/[id].tsx
+++ b/apps/mobile/app/(tabs)/players/edit/[id].tsx
@@ -4,6 +4,7 @@ import { Alert, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { doc, updateDoc, Timestamp } from 'firebase/firestore'
+import { getGoalkeeping } from '@fulbito/utils'
 import { db } from '@/lib/firebase'
 import { PlayerEditForm, type PlayerEditFormValues } from '@/components/players/edit/player-edit-form'
 import { useIsAdmin } from '@/hooks/use-is-admin'
@@ -27,6 +28,7 @@ export default function EditPlayerScreen() {
     technical: 5,
     tactical: 5,
     psychological: 5,
+    goalkeeping: 5,
   })
   const [saving, setSaving] = useState(false)
 
@@ -52,6 +54,7 @@ export default function EditPlayerScreen() {
         technical: Number(player.skills?.technical ?? base),
         tactical: Number(player.skills?.tactical ?? base),
         psychological: Number(player.skills?.psychological ?? base),
+        goalkeeping: getGoalkeeping(player),
       })
     }
   }, [player])
@@ -72,6 +75,7 @@ export default function EditPlayerScreen() {
         position: values.position,
         skills,
         skill,
+        goalkeeping: values.goalkeeping,
         updatedAt: Timestamp.now(),
       })
       await reload()

--- a/apps/mobile/components/history/matchCard.tsx
+++ b/apps/mobile/components/history/matchCard.tsx
@@ -61,6 +61,7 @@ export function MatchCard({ match: m, players, isAdmin, onEdit, onDelete }: Prop
           players={m.teamA}
           winner={winA}
           loser={winB}
+          goalkeeperIds={m.goalkeeperIds}
           colors={colors}
           radii={radii}
           spacing={spacing}
@@ -70,6 +71,7 @@ export function MatchCard({ match: m, players, isAdmin, onEdit, onDelete }: Prop
           players={m.teamB}
           winner={winB}
           loser={winA}
+          goalkeeperIds={m.goalkeeperIds}
           colors={colors}
           radii={radii}
           spacing={spacing}
@@ -108,6 +110,7 @@ function TeamColumn({
   players,
   winner,
   loser,
+  goalkeeperIds,
   colors,
   radii,
   spacing,
@@ -116,6 +119,7 @@ function TeamColumn({
   players: MatchPlayer[]
   winner: boolean
   loser: boolean
+  goalkeeperIds?: string[]
   colors: TeamColumnColors
   radii: TeamColumnRadii
   spacing: TeamColumnSpacing
@@ -127,7 +131,7 @@ function TeamColumn({
       {players.map((p) => (
         <View key={p.id} style={styles.playerRow}>
           <Text style={[styles.playerName, { color: colors.text }]} numberOfLines={1}>
-            {p.name}
+            {goalkeeperIds?.includes(p.id) ? '🧤 ' : ''}{p.name}
           </Text>
           <Text style={[styles.playerStats, { color: colors.muted }]}>
             {p.goals}⚽ {p.performance}★

--- a/apps/mobile/components/match/matchForm.tsx
+++ b/apps/mobile/components/match/matchForm.tsx
@@ -1,5 +1,5 @@
 import type { Match, Player } from '@fulbito/types'
-import { balanceRemainingPlayers } from '@fulbito/utils'
+import { balanceRemainingPlayers, getGoalkeeping } from '@fulbito/utils'
 import { useMemo, useState } from 'react'
 import { Alert, ScrollView, StyleSheet, View } from 'react-native'
 
@@ -8,6 +8,7 @@ import { useAppTheme } from '@/hooks/use-theme'
 import { AutoGenerateButton } from './matchForm/autoGenerateButton'
 import { DateField } from './matchForm/dateField'
 import { FormActions } from './matchForm/formActions'
+import { GoalkeeperSection } from './matchForm/goalkeeperSection'
 import { buildMatchPayload, computeTeamStats, toPlayerInfo } from './matchForm/helpers'
 import { NameField } from './matchForm/nameField'
 import { PoolSection } from './matchForm/poolSection'
@@ -51,6 +52,10 @@ export function MatchForm({
   const [matchType, setMatchType] = useState<MatchType>((initial?.type as MatchType) ?? '5v5')
   const [matchName, setMatchName] = useState(initial?.name ?? '')
   const playersPerTeam = useMemo(() => parseInt(matchType.split('v')[0], 10), [matchType])
+  const MAX_GOALKEEPERS = 2
+  const [goalkeeperIds, setGoalkeeperIds] = useState<Set<string>>(
+    () => new Set(initial?.goalkeeperIds ?? []),
+  )
 
   // ── State hooks ─────────────────────────────────────────────────────────────
   const pool = usePool(players, initial)
@@ -78,6 +83,20 @@ export function MatchForm({
   const handlePoolChange = (ids: Set<string>) => {
     pool.setPoolIds(ids)
     teams.filterByPool(ids)
+    setGoalkeeperIds((prev) => new Set([...prev].filter((id) => ids.has(id))))
+  }
+
+  const toggleGoalkeeper = (id: string) => {
+    setGoalkeeperIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        if (next.size >= MAX_GOALKEEPERS) return prev
+        next.add(id)
+      }
+      return next
+    })
   }
 
   const handleTypeChange = (t: MatchType) => {
@@ -86,19 +105,32 @@ export function MatchForm({
   }
 
   const generateRemainingTeams = () => {
-    const pinnedAPlayers = pool.poolPlayers.filter((p) => teams.pinnedA.has(p.id)).map(toPlayerInfo)
-    const pinnedBPlayers = pool.poolPlayers.filter((p) => teams.pinnedB.has(p.id)).map(toPlayerInfo)
+    const toInfo = (p: Player) => {
+      const info = toPlayerInfo(p)
+      return goalkeeperIds.has(p.id) ? { ...info, skill: getGoalkeeping(p) } : info
+    }
+    const normSkill = (s: number | 'unknown') => (s === 'unknown' ? 5 : s)
     const pinnedIds = new Set([...teams.pinnedA, ...teams.pinnedB])
+
+    const seedA = pool.poolPlayers.filter((p) => teams.pinnedA.has(p.id)).map(toInfo)
+    const seedB = pool.poolPlayers.filter((p) => teams.pinnedB.has(p.id)).map(toInfo)
+
+    const unpinnedKeepers = pool.poolPlayers
+      .filter((p) => goalkeeperIds.has(p.id) && !pinnedIds.has(p.id))
+      .map(toInfo)
+      .sort((a, b) => normSkill(b.skill) - normSkill(a.skill))
+    const keeperSeededIds = new Set<string>()
+    for (const k of unpinnedKeepers) {
+      if (seedA.length <= seedB.length) seedA.push(k)
+      else seedB.push(k)
+      keeperSeededIds.add(k.id)
+    }
+
     const unassigned = pool.poolPlayers
-      .filter((p) => !pinnedIds.has(p.id))
-      .map(toPlayerInfo)
+      .filter((p) => !pinnedIds.has(p.id) && !keeperSeededIds.has(p.id))
+      .map(toInfo)
       .sort(() => Math.random() - 0.5)
-    const result = balanceRemainingPlayers(
-      unassigned,
-      pinnedAPlayers,
-      pinnedBPlayers,
-      playersPerTeam,
-    )
+    const result = balanceRemainingPlayers(unassigned, seedA, seedB, playersPerTeam)
     teams.setTeamA(result.teamA.players.map((p) => ({ id: p.id, name: p.name })))
     teams.setTeamB(result.teamB.players.map((p) => ({ id: p.id, name: p.name })))
   }
@@ -119,6 +151,7 @@ export function MatchForm({
         perfA: scores.perfA,
         perfB: scores.perfB,
         shirtsResponsibleId: pickShirtsResponsible(shirts.shirtsResponsibleId, shirts.dutyPoolIds),
+        goalkeeperIds: [...goalkeeperIds],
       })
       await onSave(payload)
     } catch (e) {
@@ -153,6 +186,13 @@ export function MatchForm({
         onConfirm={handlePoolChange}
       />
 
+      <GoalkeeperSection
+        poolPlayers={pool.poolPlayers}
+        goalkeeperIds={goalkeeperIds}
+        maxSize={MAX_GOALKEEPERS}
+        onToggle={toggleGoalkeeper}
+      />
+
       <TeamAssignmentSection
         playersPerTeam={playersPerTeam}
         poolPlayers={pool.poolPlayers}
@@ -160,6 +200,7 @@ export function MatchForm({
         teamB={teams.teamB}
         pinnedA={teams.pinnedA}
         pinnedB={teams.pinnedB}
+        goalkeeperIds={goalkeeperIds}
         stats={teamStats}
         onConfirmTeam={teams.confirmTeam}
         onRemoveFromTeam={teams.removeFromTeam}

--- a/apps/mobile/components/match/matchForm/goalkeeperSection.tsx
+++ b/apps/mobile/components/match/matchForm/goalkeeperSection.tsx
@@ -1,0 +1,84 @@
+import type { Player } from '@fulbito/types'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+
+import { useAppTheme } from '@/hooks/use-theme'
+
+import { FormLabel } from './formLabel'
+
+type Props = {
+  poolPlayers: Player[]
+  goalkeeperIds: Set<string>
+  maxSize: number
+  onToggle: (id: string) => void
+}
+
+export function GoalkeeperSection({ poolPlayers, goalkeeperIds, maxSize, onToggle }: Props) {
+  const { colors, radii } = useAppTheme()
+
+  return (
+    <>
+      <FormLabel text={`Arqueros (${goalkeeperIds.size}/${maxSize})`} />
+      {poolPlayers.length === 0 ? (
+        <Text style={[styles.hint, { color: colors.muted }]}>
+          Seleccioná jugadores arriba para elegir arqueros.
+        </Text>
+      ) : (
+        <View style={styles.chipsWrap}>
+          {poolPlayers.map((p) => {
+            const active = goalkeeperIds.has(p.id)
+            const disabled = !active && goalkeeperIds.size >= maxSize
+            return (
+              <TouchableOpacity
+                key={p.id}
+                onPress={() => onToggle(p.id)}
+                disabled={disabled}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active, disabled }}
+                accessibilityLabel={
+                  active ? `Quitar a ${p.name} como arquero` : `Marcar a ${p.name} como arquero`
+                }
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: active ? colors.brand : 'transparent',
+                    borderColor: active ? colors.brand : colors.border,
+                    borderRadius: radii.pill,
+                    opacity: disabled ? 0.4 : 1,
+                  },
+                ]}
+              >
+                <Text style={[styles.chipText, { color: active ? '#fff' : colors.muted }]}>
+                  🧤 {p.name}
+                </Text>
+              </TouchableOpacity>
+            )
+          })}
+        </View>
+      )}
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  hint: {
+    fontSize: 13,
+    paddingVertical: 6,
+  },
+  chipsWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingVertical: 4,
+  },
+  chip: {
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/components/match/matchForm/helpers.ts
+++ b/apps/mobile/components/match/matchForm/helpers.ts
@@ -66,6 +66,7 @@ export type BuildPayloadInput = {
   perfA: Record<string, string>
   perfB: Record<string, string>
   shirtsResponsibleId: string | null
+  goalkeeperIds?: string[]
 }
 
 export function buildMatchPayload(input: BuildPayloadInput): Omit<Match, 'id'> {
@@ -90,5 +91,6 @@ export function buildMatchPayload(input: BuildPayloadInput): Omit<Match, 'id'> {
     teamA: buildTeamPlayers(input.teamA, input.goalsA, input.perfA),
     teamB: buildTeamPlayers(input.teamB, input.goalsB, input.perfB),
     shirtsResponsibleId: input.shirtsResponsibleId,
+    goalkeeperIds: input.goalkeeperIds ?? [],
   }
 }

--- a/apps/mobile/components/match/matchForm/shirtsSection.tsx
+++ b/apps/mobile/components/match/matchForm/shirtsSection.tsx
@@ -49,8 +49,8 @@ export function ShirtsSection({
   const pickRandom = () => {
     const candidates = options.filter((o) => o.id !== '' && !o.disabled)
     if (candidates.length === 0) return
-    const minDuties = Math.min(...candidates.map((c) => c.duties))
-    const pool = candidates.filter((c) => c.duties === minDuties)
+    const minDuties = Math.min(...candidates.map((c) => (c as { duties: number }).duties))
+    const pool = candidates.filter((c) => (c as { duties: number }).duties === minDuties)
     const picked = pool[Math.floor(Math.random() * pool.length)]
     onChange(picked.id)
   }

--- a/apps/mobile/components/match/matchForm/teamAssignmentSection.tsx
+++ b/apps/mobile/components/match/matchForm/teamAssignmentSection.tsx
@@ -17,6 +17,7 @@ type Props = {
   teamB: RecordingPlayer[]
   pinnedA: Set<string>
   pinnedB: Set<string>
+  goalkeeperIds: Set<string>
   stats: TeamStats
   onConfirmTeam: (side: TeamSide, players: RecordingPlayer[]) => void
   onRemoveFromTeam: (side: TeamSide, id: string) => void
@@ -29,6 +30,7 @@ export function TeamAssignmentSection({
   teamB,
   pinnedA,
   pinnedB,
+  goalkeeperIds,
   stats,
   onConfirmTeam,
   onRemoveFromTeam,
@@ -43,6 +45,7 @@ export function TeamAssignmentSection({
           side="a"
           team={teamA}
           pinned={pinnedA}
+          goalkeeperIds={goalkeeperIds}
           playersPerTeam={playersPerTeam}
           stats={{ skill: stats.skillA, phys: stats.physA, winPct: stats.winPctA }}
           onAdd={() => setSelectingTeam('a')}
@@ -52,6 +55,7 @@ export function TeamAssignmentSection({
           side="b"
           team={teamB}
           pinned={pinnedB}
+          goalkeeperIds={goalkeeperIds}
           playersPerTeam={playersPerTeam}
           stats={{ skill: stats.skillB, phys: stats.physB, winPct: stats.winPctB }}
           onAdd={() => setSelectingTeam('b')}
@@ -81,6 +85,7 @@ function TeamColumn({
   side,
   team,
   pinned,
+  goalkeeperIds,
   playersPerTeam,
   stats,
   onAdd,
@@ -89,6 +94,7 @@ function TeamColumn({
   side: TeamSide
   team: RecordingPlayer[]
   pinned: Set<string>
+  goalkeeperIds: Set<string>
   playersPerTeam: number
   stats: { skill: number; phys: number; winPct: number }
   onAdd: () => void
@@ -106,6 +112,7 @@ function TeamColumn({
       {team.map((p) => (
         <View key={p.id} style={[styles.playerRow, { borderColor: colors.border }]}>
           <Text style={[styles.playerName, { color: colors.text }]} numberOfLines={1}>
+            {goalkeeperIds.has(p.id) ? '🧤 ' : ''}
             {p.name}
             {pinned.has(p.id) ? ' ⭐' : ''}
           </Text>

--- a/apps/mobile/components/players/detail/player-skill-bars.tsx
+++ b/apps/mobile/components/players/detail/player-skill-bars.tsx
@@ -7,6 +7,7 @@ import { Fonts, Radii, Spacing } from '@/constants/theme'
 
 type Props = {
   skills: CatSkills
+  goalkeeping?: number
 }
 
 type SkillRowProps = {
@@ -43,13 +44,14 @@ function SkillRow({ label, value }: SkillRowProps) {
   )
 }
 
-export function PlayerSkillBars({ skills }: Props) {
+export function PlayerSkillBars({ skills, goalkeeping }: Props) {
   return (
     <View style={styles.container}>
       <SkillRow label="Físico" value={skills.physical} />
       <SkillRow label="Técnico" value={skills.technical} />
       <SkillRow label="Táctico" value={skills.tactical} />
       <SkillRow label="Mental" value={skills.psychological} />
+      {goalkeeping != null ? <SkillRow label="Arquero" value={goalkeeping} /> : null}
     </View>
   )
 }

--- a/apps/mobile/components/players/edit/player-edit-form.tsx
+++ b/apps/mobile/components/players/edit/player-edit-form.tsx
@@ -21,6 +21,7 @@ export type PlayerEditFormValues = {
   technical: number
   tactical: number
   psychological: number
+  goalkeeping: number
 }
 
 type Props = {
@@ -167,6 +168,20 @@ export function PlayerEditForm({ values, onChange, saving, onSave, onCancel }: P
           <ThemedText style={[styles.avgValue, { color: colors.brand }]}>
             Lv {overall.toFixed(2)}
           </ThemedText>
+        </View>
+
+        {/* ── Nivel de arquero ─────────────────────────────── */}
+        <ThemedText style={[styles.label, { color: colors.muted }]}>Nivel de arquero</ThemedText>
+        <View
+          style={[
+            styles.skillsCard,
+            { backgroundColor: colors.surface, borderColor: colors.border, borderRadius: radii.md },
+          ]}>
+          <SkillStepper
+            label="Arquero"
+            value={values.goalkeeping}
+            onChange={(v) => set('goalkeeping', v)}
+          />
         </View>
 
         {/* ── Acciones ─────────────────────────────────────── */}

--- a/apps/mobile/hooks/use-matches-data.ts
+++ b/apps/mobile/hooks/use-matches-data.ts
@@ -54,6 +54,7 @@ async function fetchMatchesAndPlayers(): Promise<{ matches: Match[]; players: Pl
       teamB: teams.B,
       shirtsResponsibleId: data.shirtsResponsibleId ?? null,
       mvpId: data.mvpId ?? null,
+      goalkeeperIds: data.goalkeeperIds ?? [],
     } as Match
   })
 
@@ -121,11 +122,12 @@ export function useMatchesData(): MatchesDataState {
 
   const addMatch = useCallback(
     async (m: Omit<Match, 'id'>) => {
-      const { teamA, teamB, mvpId, ...rest } = m
+      const { teamA, teamB, mvpId, goalkeeperIds, ...rest } = m
       const nextMvpId = mvpId ?? null
       const ref = await addDoc(collection(db, 'matches'), {
         ...rest,
         mvpId: nextMvpId,
+        goalkeeperIds: goalkeeperIds ?? [],
         date: Timestamp.fromDate(new Date(m.date)),
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now(),
@@ -155,12 +157,13 @@ export function useMatchesData(): MatchesDataState {
 
   const updateMatch = useCallback(
     async (id: string, m: Omit<Match, 'id'>) => {
-      const { teamA, teamB, mvpId, ...rest } = m
+      const { teamA, teamB, mvpId, goalkeeperIds, ...rest } = m
       const prevMvpId = matches.find(x => x.id === id)?.mvpId ?? null
       const nextMvpId = mvpId ?? null
       await updateDoc(doc(db, 'matches', id), {
         ...rest,
         mvpId: nextMvpId,
+        goalkeeperIds: goalkeeperIds ?? [],
         date: Timestamp.fromDate(new Date(m.date)),
         updatedAt: Timestamp.now(),
       })

--- a/apps/mobile/hooks/use-players-data.ts
+++ b/apps/mobile/hooks/use-players-data.ts
@@ -16,6 +16,7 @@ function docToPlayer(id: string, data: Record<string, any>): Player {
     skills: data.skills,
     photoUrl: data.photoUrl,
     shirtDutiesCount: data.shirtDutiesCount ?? 0,
+    goalkeeping: data.goalkeeping ?? undefined,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),
   }

--- a/apps/mobile/lib/shape.ts
+++ b/apps/mobile/lib/shape.ts
@@ -8,6 +8,7 @@ type RawPlayer = {
   skills?: unknown
   photoUrl?: string | null
   shirtDutiesCount?: number
+  goalkeeping?: number
   createdAt: Date | string
   updatedAt: Date | string
 }
@@ -21,6 +22,7 @@ export function shapeStorePlayers(players: RawPlayer[]): Player[] {
     skills: p.skills as Player['skills'],
     photoUrl: p.photoUrl ?? undefined,
     shirtDutiesCount: p.shirtDutiesCount ?? 0,
+    goalkeeping: p.goalkeeping ?? undefined,
     createdAt: p.createdAt instanceof Date ? p.createdAt : new Date(p.createdAt),
     updatedAt: p.updatedAt instanceof Date ? p.updatedAt : new Date(p.updatedAt),
   }))

--- a/apps/web/src/app/history/historyClient.tsx
+++ b/apps/web/src/app/history/historyClient.tsx
@@ -222,6 +222,11 @@ export default function HistoryClient({
                       >
                         <span className="text-sm truncate">{p.name}</span>
                         <span className="flex items-center gap-1.5 text-xs text-gray-500 shrink-0">
+                          {m.goalkeeperIds?.includes(p.id) && (
+                            <span aria-label="Arquero" role="img">
+                              🧤
+                            </span>
+                          )}
                           {m.mvpId === p.id && (
                             <span aria-label="MVP" role="img">
                               🏆
@@ -243,6 +248,11 @@ export default function HistoryClient({
                       >
                         <span className="text-sm truncate">{p.name}</span>
                         <span className="flex items-center gap-1.5 text-xs text-gray-500 shrink-0">
+                          {m.goalkeeperIds?.includes(p.id) && (
+                            <span aria-label="Arquero" role="img">
+                              🧤
+                            </span>
+                          )}
                           {m.mvpId === p.id && (
                             <span aria-label="MVP" role="img">
                               🏆
@@ -396,12 +406,33 @@ function RecordModal({
     initial?.shirtsResponsibleId ?? null,
   );
   const [mvpId, setMvpId] = useState<string | null>(initial?.mvpId ?? null);
+  const [goalkeeperIds, setGoalkeeperIds] = useState<string[]>(
+    initial?.goalkeeperIds ?? [],
+  );
+  const MAX_GOALKEEPERS = 2;
 
   useEffect(() => {
     if (!mvpId) return;
     const inTeams = [...teamA, ...teamB].some((p) => p.id === mvpId);
     if (!inTeams) setMvpId(null);
   }, [teamA, teamB, mvpId]);
+
+  useEffect(() => {
+    const ids = new Set([...teamA, ...teamB].map((p) => p.id));
+    setGoalkeeperIds((prev) => {
+      const next = prev.filter((id) => ids.has(id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [teamA, teamB]);
+
+  const toggleGoalkeeper = (id: string) =>
+    setGoalkeeperIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((x) => x !== id)
+        : prev.length >= MAX_GOALKEEPERS
+          ? prev
+          : [...prev, id],
+    );
 
   const [goalsA, setGoalsA] = useState<Record<string, number>>(() =>
     Object.fromEntries(
@@ -518,7 +549,7 @@ function RecordModal({
         name: matchName.trim() || undefined,
       };
 
-      await onSave({ ...m, shirtsResponsibleId: chosen, mvpId });
+      await onSave({ ...m, shirtsResponsibleId: chosen, mvpId, goalkeeperIds });
 
       alert("Partido guardado correctamente!");
       onClose();
@@ -838,6 +869,52 @@ function RecordModal({
                 })()}
               </select>
             </div>
+          </div>
+        </div>
+
+        <div className="mt-3 bg-purple-50 border border-purple-200 rounded p-3">
+          <div className="flex items-center justify-between gap-3 mb-2">
+            <div className="text-sm">
+              <div className="font-semibold flex items-center gap-1.5">
+                <span aria-hidden="true">🧤</span>
+                Arqueros
+              </div>
+              <div className="text-gray-800">
+                Marcá quién atajó (máximo {MAX_GOALKEEPERS})
+              </div>
+            </div>
+            <span className="text-sm px-2 py-0.5 rounded bg-purple-100 text-purple-800 shrink-0">
+              {goalkeeperIds.length} / {MAX_GOALKEEPERS}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {[...teamA, ...teamB].length === 0 ? (
+              <span className="text-sm text-gray-600">
+                Asigná jugadores a los equipos para elegir arqueros.
+              </span>
+            ) : (
+              [...teamA, ...teamB].map((p) => {
+                const active = goalkeeperIds.includes(p.id);
+                const disabled =
+                  !active && goalkeeperIds.length >= MAX_GOALKEEPERS;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => toggleGoalkeeper(p.id)}
+                    disabled={disabled}
+                    aria-pressed={active}
+                    className={`text-sm px-3 py-1 rounded-full border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                      active
+                        ? "bg-brand text-white border-brand"
+                        : "bg-white text-gray-700 border-gray-300 hover:bg-gray-100"
+                    }`}
+                  >
+                    🧤 {p.name}
+                  </button>
+                );
+              })
+            )}
           </div>
         </div>
 

--- a/apps/web/src/app/match/matchClient.tsx
+++ b/apps/web/src/app/match/matchClient.tsx
@@ -5,7 +5,7 @@ import { usePlayerStore , Player} from '@/store/usePlayerStore'
 import { useMatchStore } from '@/store/useMatchStore'
 import { buildPlayedBeforeSet, getEligiblePlayerIds, computeLeastAssignedPoolIds } from '@/lib/shirtDuty'
 import { balanceRemainingPlayers, balanceTeams, PlayerInfo, TeamResult } from '@/lib/teamUtils'
-import { calculateAllCurrentStreaks } from '@/lib/playerStats'
+import { calculateAllCurrentStreaks, getGoalkeeping } from '@/lib/playerStats'
 import { DropColumn, DraggableItem } from '@/components/DragAndDrop'
 
 type MatchType = '5v5' | '6v6' | '7v7' | '8v8' | '9v9' | '10v10'
@@ -31,6 +31,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
 
   const [selectionOpen, setSelectionOpen] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [goalkeeperIds, setGoalkeeperIds] = useState<Set<string>>(new Set())
   const [autoTeams, setAutoTeams] = useState<{ teamA: TeamResult, teamB: TeamResult } | null>(null)
   const [streakSeparated, setStreakSeparated] = useState(false)
   const [shirtsResponsibleId, setShirtsResponsibleId] = useState<string | null>(null)
@@ -44,6 +45,8 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   // search in player selection
   const [playerQuery, setPlayerQuery] = useState('')
 
+  const MAX_GOALKEEPERS = 2
+
   const playedBefore = useMemo(() => buildPlayedBeforeSet(allMatches), [allMatches])
 
   const selectedPlayers: PlayerInfo[] = useMemo(() => {
@@ -53,11 +56,14 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
       .map(p => ({
         id: p.id,
         name: p.name,
-        skill: (p.skill ?? 'unknown') as number | 'unknown',
+        // Designated goalkeepers are balanced by their goalkeeping level, not their overall skill.
+        skill: goalkeeperIds.has(p.id)
+          ? getGoalkeeping(p)
+          : ((p.skill ?? 'unknown') as number | 'unknown'),
         position: p.position,
         physical: (p.skills?.physical ?? 'unknown') as number | 'unknown'
       }))
-  }, [players, selected])
+  }, [players, selected, goalkeeperIds])
 
   const unassignedManual = useMemo(() => {
     const ids = new Set([...manualA, ...manualB].map(p => p.id))
@@ -65,10 +71,32 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   }, [selectedPlayers, manualA, manualB])
 
   const toggleSelect = (id: string) => {
+    const wasSelected = selected.has(id)
     setSelected(prev => {
       const s = new Set(prev)
       if (s.has(id)) s.delete(id)
       else s.add(id)
+      return s
+    })
+    if (wasSelected) {
+      setGoalkeeperIds(prev => {
+        if (!prev.has(id)) return prev
+        const s = new Set(prev)
+        s.delete(id)
+        return s
+      })
+    }
+  }
+
+  const toggleGoalkeeper = (id: string) => {
+    setGoalkeeperIds(prev => {
+      const s = new Set(prev)
+      if (s.has(id)) {
+        s.delete(id)
+      } else {
+        if (s.size >= MAX_GOALKEEPERS) return prev
+        s.add(id)
+      }
       return s
     })
   }
@@ -79,6 +107,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
       return
     }
     setSelected(new Set())
+    setGoalkeeperIds(new Set())
     setAutoTeams(null)
     setStreakSeparated(false)
     setManualOpen(false)
@@ -141,6 +170,18 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   }
 
   const buildTeams = (pool: PlayerInfo[], streaks: Record<string, { kind: 'win' | 'loss' | null; count: number }>) => {
+    // Designated goalkeepers take precedence: seed one per team so they end up split,
+    // then balance the rest around them (keepers already carry their goalkeeping level as skill).
+    const keepers = pool.filter(p => goalkeeperIds.has(p.id))
+    if (keepers.length > 0) {
+      const normSkill = (s: number | 'unknown') => (s === 'unknown' ? 5 : s)
+      const sortedKeepers = [...keepers].sort((a, b) => normSkill(b.skill) - normSkill(a.skill))
+      const seedA: PlayerInfo[] = []
+      const seedB: PlayerInfo[] = []
+      sortedKeepers.forEach((k, i) => (i % 2 === 0 ? seedA : seedB).push(k))
+      const rest = pool.filter(p => !goalkeeperIds.has(p.id))
+      return { teams: balanceRemainingPlayers(rest, seedA, seedB, playersPerTeam), hadStreak: false }
+    }
     const { seedA, seedB, rest } = splitByStreak(pool, streaks)
     if (seedA.length > 0 && seedB.length > 0) {
       return { teams: balanceRemainingPlayers(rest, seedA, seedB, playersPerTeam), hadStreak: true }
@@ -296,6 +337,9 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
                   <span className={`ml-3 px-2 py-0.5 rounded ${missing === 0 ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
                     Faltan: {missing}
                   </span>
+                  <span className="ml-3 px-2 py-0.5 rounded bg-purple-100 text-purple-800">
+                    🧤 Arqueros: {goalkeeperIds.size} / {MAX_GOALKEEPERS}
+                  </span>
                 </span>
               )
             })()}
@@ -317,14 +361,32 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
                 return p.name.toLowerCase().includes(q)
               })
               .map(p => (
-              <label key={p.id} className="flex items-center gap-2 bg-gray-50 rounded px-3 py-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={selected.has(p.id)}
-                  onChange={() => toggleSelect(p.id)}
-                />
-                <span className="font-medium">{p.name}</span>
-              </label>
+              <div key={p.id} className="flex items-center justify-between gap-2 bg-gray-50 rounded px-3 py-2">
+                <label className="flex items-center gap-2 cursor-pointer flex-1 min-w-0">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(p.id)}
+                    onChange={() => toggleSelect(p.id)}
+                  />
+                  <span className="font-medium truncate">{p.name}</span>
+                </label>
+                {selected.has(p.id) && (
+                  <button
+                    type="button"
+                    onClick={() => toggleGoalkeeper(p.id)}
+                    disabled={!goalkeeperIds.has(p.id) && goalkeeperIds.size >= MAX_GOALKEEPERS}
+                    aria-pressed={goalkeeperIds.has(p.id)}
+                    title={goalkeeperIds.has(p.id) ? 'Quitar como arquero' : 'Marcar como arquero'}
+                    className={`shrink-0 text-xs px-2 py-1 rounded border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                      goalkeeperIds.has(p.id)
+                        ? 'bg-brand text-white border-brand'
+                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
+                    }`}
+                  >
+                    🧤 Arquero
+                  </button>
+                )}
+              </div>
             ))}
           </div>
           <div className="flex gap-3 justify-center mt-4">
@@ -382,8 +444,8 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
           )}
 
           <div className="grid md:grid-cols-2 gap-4">
-            <TeamCard title="Team A" team={autoTeams.teamA} color="blue" winProbability={probA} />
-            <TeamCard title="Team B" team={autoTeams.teamB} color="red" winProbability={probB} />
+            <TeamCard title="Team A" team={autoTeams.teamA} color="blue" winProbability={probA} goalkeeperIds={goalkeeperIds} />
+            <TeamCard title="Team B" team={autoTeams.teamB} color="red" winProbability={probB} goalkeeperIds={goalkeeperIds} />
           </div>
 
           <div className="mt-6 border-t pt-4">
@@ -440,7 +502,7 @@ export default function MatchClient({ players: initialPlayers }: { players: Play
   )
 }
 
-function TeamCard({ title, team, color, winProbability }: { title: string, team: TeamResult, color: 'blue' | 'red', winProbability?: number }) {
+function TeamCard({ title, team, color, winProbability, goalkeeperIds }: { title: string, team: TeamResult, color: 'blue' | 'red', winProbability?: number, goalkeeperIds?: Set<string> }) {
   return (
     <div className="border rounded-lg p-4">
       <h3 className={`text-center font-semibold mb-3 ${color === 'blue' ? 'text-blue-700' : 'text-red-700'}`}>{title}</h3>
@@ -448,6 +510,7 @@ function TeamCard({ title, team, color, winProbability }: { title: string, team:
         {team.players.map((p: PlayerInfo) => (
           <div key={p.id} className="bg-gray-50 rounded px-3 py-2 text-center">
             <strong>{p.name}</strong>
+            {goalkeeperIds?.has(p.id) && <span className="ml-2" title="Arquero">🧤</span>}
           </div>
         ))}
       </div>

--- a/apps/web/src/app/players/PlayerForm.tsx
+++ b/apps/web/src/app/players/PlayerForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
 import { usePlayerStore } from '@/store/usePlayerStore'
+import { getGoalkeeping } from '@fulbito/utils'
 
 type Props = {
   mode: 'create' | 'edit'
@@ -24,6 +25,8 @@ export default function PlayerForm({ mode, playerId }: Props) {
   })
   const [photoFile, setPhotoFile] = useState<File | null>(null)
   const [photoPreview, setPhotoPreview] = useState<string | null>(null)
+  const [goalkeeping, setGoalkeeping] = useState<string>('5')
+  const [gkTouched, setGkTouched] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
@@ -40,6 +43,8 @@ export default function PlayerForm({ mode, playerId }: Props) {
           psychological: String(p.skills?.psychological ?? base)
         })
         setPhotoPreview(p.photoUrl ?? null)
+        setGoalkeeping(String(getGoalkeeping(p)))
+        setGkTouched(p.goalkeeping != null)
       }
     }
   }, [mode, playerId, getPlayer])
@@ -47,6 +52,8 @@ export default function PlayerForm({ mode, playerId }: Props) {
   const avgPreview = useMemo(() => (
     (+formData.physical + +formData.technical + +formData.tactical + +formData.psychological) / 4
   ), [formData])
+
+  const gkValue = gkTouched ? goalkeeping : String(Math.round(avgPreview))
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -57,6 +64,7 @@ export default function PlayerForm({ mode, playerId }: Props) {
       psychological: parseInt(formData.psychological, 10),
     }
     const avg = (skills.physical + skills.technical + skills.tactical + skills.psychological) / 4
+    const goalkeepingValue = gkTouched ? parseInt(goalkeeping, 10) : Math.round(avg)
 
     let uploadedUrl: string | undefined
     if (photoFile) {
@@ -67,9 +75,9 @@ export default function PlayerForm({ mode, playerId }: Props) {
     }
 
     if (mode === 'create') {
-      await addPlayer({ name: formData.name.trim(), position: formData.position, skills, skill: avg, ...(uploadedUrl ? { photoUrl: uploadedUrl } : {}) })
+      await addPlayer({ name: formData.name.trim(), position: formData.position, skills, skill: avg, goalkeeping: goalkeepingValue, ...(uploadedUrl ? { photoUrl: uploadedUrl } : {}) })
     } else if (playerId) {
-      await updatePlayer(playerId, { name: formData.name.trim(), position: formData.position, skills, skill: avg, ...(uploadedUrl ? { photoUrl: uploadedUrl } : {}) })
+      await updatePlayer(playerId, { name: formData.name.trim(), position: formData.position, skills, skill: avg, goalkeeping: goalkeepingValue, ...(uploadedUrl ? { photoUrl: uploadedUrl } : {}) })
     }
     router.push('/players')
   }
@@ -139,6 +147,19 @@ export default function PlayerForm({ mode, playerId }: Props) {
       </div>
 
       <div className="text-sm text-gray-800">General (promedio): <span className="font-semibold">Lv {avgPreview}</span></div>
+
+      <div>
+        <label htmlFor="goalkeeping" className="block text-sm font-medium text-black">Nivel de arquero</label>
+        <select
+          id="goalkeeping"
+          value={gkValue}
+          onChange={(e) => { setGkTouched(true); setGoalkeeping(e.target.value) }}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand"
+        >
+          {[1,2,3,4,5,6,7,8,9,10].map(n => <option key={n} value={n}>{n}</option>)}
+        </select>
+        <p className="mt-1 text-xs text-gray-700">Por defecto sigue el promedio del jugador. Editalo para fijar un valor.</p>
+      </div>
 
       <div>
         <label htmlFor="position" className="block text-sm font-medium text-black">Posición</label>

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -13,6 +13,7 @@ import RadarChart from '@/components/RadarChart'
 import PlayerCard from '@/components/PlayerCard'
 import { useRef } from 'react'
 import { calculateCurrentStreakForPlayer } from "@/lib/playerStats";
+import { getGoalkeeping } from "@fulbito/utils";
 import { useFirebaseAuth } from '@/contexts/FirebaseAuthContext'
 
 export default function PlayerDetailPage() {
@@ -46,6 +47,7 @@ export default function PlayerDetailPage() {
   }, [playersInit, matchesInit, initPlayersLoad, initMatchesLoad]);
 
   const [editMode, setEditMode] = useState(false);
+  const [gkTouched, setGkTouched] = useState(false);
   const [form, setForm] = useState({
     name: "",
     position: "PLAYER",
@@ -53,6 +55,7 @@ export default function PlayerDetailPage() {
     technical: "5",
     tactical: "5",
     psychological: "5",
+    goalkeeping: "5",
   });
 
   useEffect(() => {
@@ -65,7 +68,9 @@ export default function PlayerDetailPage() {
         technical: String(player.skills?.technical ?? base),
         tactical: String(player.skills?.tactical ?? base),
         psychological: String(player.skills?.psychological ?? base),
+        goalkeeping: String(getGoalkeeping(player)),
       });
+      setGkTouched(player.goalkeeping != null);
     }
   }, [player]);
 
@@ -166,11 +171,13 @@ export default function PlayerDetailPage() {
         skills.tactical +
         skills.psychological) /
       4;
+    const goalkeeping = gkTouched ? parseInt(form.goalkeeping, 10) : Math.round(avg);
     updatePlayer(player.id, {
       name: form.name.trim(),
       position: form.position,
       skills,
       skill: avg,
+      goalkeeping,
     });
     setEditMode(false);
   };
@@ -200,6 +207,7 @@ export default function PlayerDetailPage() {
   const avgPreview =
     (+form.physical + +form.technical + +form.tactical + +form.psychological) /
     4;
+  const gkQuickValue = gkTouched ? form.goalkeeping : String(Math.round(avgPreview));
   return (
     <div className="max-w-5xl mx-auto px-4 py-8">
       <div className="mb-6 flex gap-5 items-center justify-between">
@@ -267,6 +275,7 @@ export default function PlayerDetailPage() {
               overall={overallAvg}
               photoUrl={player.photoUrl}
               skills={catSkills}
+              goalkeeping={getGoalkeeping(player)}
               onAvatarClick={onAvatarClick}
             />
             {isAdmin && (
@@ -348,6 +357,20 @@ export default function PlayerDetailPage() {
               onChange={(e) =>
                 setForm({ ...form, psychological: e.target.value })
               }
+              className="w-full border rounded px-3 py-2 focus:border-brand focus:ring-brand"
+            >
+              {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Arquero</label>
+            <select
+              value={gkQuickValue}
+              onChange={(e) => { setGkTouched(true); setForm({ ...form, goalkeeping: e.target.value }) }}
               className="w-full border rounded px-3 py-2 focus:border-brand focus:ring-brand"
             >
               {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (

--- a/apps/web/src/components/PlayerCard.tsx
+++ b/apps/web/src/components/PlayerCard.tsx
@@ -8,11 +8,12 @@ export type PlayerCardProps = {
   photoUrl?: string
   // category skills 1-10; we map them into -like six stats
   skills: { physical: SkillValue; technical: SkillValue; tactical: SkillValue; psychological: SkillValue }
+  goalkeeping?: number
   className?: string
   onAvatarClick?: () => void
 }
 
-export default function PlayerCard({ overall, photoUrl, skills, className, onAvatarClick }: PlayerCardProps) {
+export default function PlayerCard({ overall, photoUrl, skills, goalkeeping, className, onAvatarClick }: PlayerCardProps) {
   const pathD = "M120 6 C160 6 188 12 207 26 C224 38 232 56 236 75 L236 255 C236 292 205 321 120 354 C35 321 4 292 4 255 L4 75 C8 56 16 38 33 26 C52 12 80 6 120 6 Z";
 
   return (
@@ -67,6 +68,9 @@ export default function PlayerCard({ overall, photoUrl, skills, className, onAva
           <div className="flex text-center gap-2"><span>{skills.technical}</span><span>Técnico</span></div>
           <div className="flex text-center gap-2"><span>{skills.tactical}</span><span>Táctico</span></div>
           <div className="flex text-center gap-2"><span>{skills.psychological}</span><span>Mental</span></div>
+          {goalkeeping != null ? (
+            <div className="col-span-2 flex justify-center text-center gap-2"><span>{goalkeeping}</span><span>Arquero</span></div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/web/src/lib/playerStats.ts
+++ b/apps/web/src/lib/playerStats.ts
@@ -1,6 +1,7 @@
 export {
   calculateCurrentStreakForPlayer,
   calculateAllCurrentStreaks,
+  getGoalkeeping,
 } from '@fulbito/utils'
 
 export type { MatchLike } from '@fulbito/types'

--- a/apps/web/src/store/useMatchStore.ts
+++ b/apps/web/src/store/useMatchStore.ts
@@ -44,6 +44,7 @@ async function fetchMatches(): Promise<Match[]> {
       teamB: teams.B,
       shirtsResponsibleId: data.shirtsResponsibleId ?? null,
       mvpId: data.mvpId ?? null,
+      goalkeeperIds: data.goalkeeperIds ?? [],
     }
   })
 }
@@ -77,11 +78,12 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
     set({ matches, matchesInit: 'loaded' })
   },
   addMatch: async (m) => {
-    const { teamA, teamB, mvpId, ...rest } = m
+    const { teamA, teamB, mvpId, goalkeeperIds, ...rest } = m
     const nextMvpId = mvpId ?? null
     const ref = await addDoc(collection(db, 'matches'), {
       ...rest,
       mvpId: nextMvpId,
+      goalkeeperIds: goalkeeperIds ?? [],
       date: Timestamp.fromDate(new Date(m.date)),
       createdAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
@@ -106,12 +108,13 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
     return ref.id
   },
   updateMatch: async (id, m) => {
-    const { teamA, teamB, mvpId, ...rest } = m
+    const { teamA, teamB, mvpId, goalkeeperIds, ...rest } = m
     const prevMvpId = get().matches.find(x => x.id === id)?.mvpId ?? null
     const nextMvpId = mvpId ?? null
     await updateDoc(doc(db, 'matches', id), {
       ...rest,
       mvpId: nextMvpId,
+      goalkeeperIds: goalkeeperIds ?? [],
       date: Timestamp.fromDate(new Date(m.date)),
       updatedAt: Timestamp.now(),
     })

--- a/apps/web/src/store/usePlayerStore.ts
+++ b/apps/web/src/store/usePlayerStore.ts
@@ -18,6 +18,7 @@ function docToPlayer(id: string, data: DocumentData): Player {
     photoUrl: data.photoUrl,
     shirtDutiesCount: data.shirtDutiesCount ?? 0,
     mvpCount: data.mvpCount ?? 0,
+    goalkeeping: data.goalkeeping ?? undefined,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),
   }

--- a/packages/firebase/src/players.ts
+++ b/packages/firebase/src/players.ts
@@ -14,6 +14,7 @@ function docToPlayer(id: string, data: Record<string, any>): Player {
     skills: data.skills,
     photoUrl: data.photoUrl,
     shirtDutiesCount: data.shirtDutiesCount ?? 0,
+    goalkeeping: data.goalkeeping ?? undefined,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt),
   }
@@ -40,6 +41,7 @@ export async function createPlayer(data: Omit<Player, 'id' | 'createdAt' | 'upda
     skills: data.skills ?? null,
     photoUrl: data.photoUrl ?? null,
     shirtDutiesCount: data.shirtDutiesCount ?? 0,
+    goalkeeping: data.goalkeeping ?? null,
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
   })

--- a/packages/types/src/match.ts
+++ b/packages/types/src/match.ts
@@ -16,6 +16,7 @@ export type Match = {
   name?: string
   shirtsResponsibleId?: string | null
   mvpId?: string | null
+  goalkeeperIds?: string[]
 }
 
 /** Minimal match shape used by streak-calculation algorithms */

--- a/packages/types/src/player.ts
+++ b/packages/types/src/player.ts
@@ -16,6 +16,7 @@ export type Player = {
   photoUrl?: string
   shirtDutiesCount?: number
   mvpCount?: number
+  goalkeeping?: number
   createdAt: Date
   updatedAt: Date
 }

--- a/packages/utils/src/playerStats.ts
+++ b/packages/utils/src/playerStats.ts
@@ -1,4 +1,12 @@
-import type { MatchLike } from '@fulbito/types'
+import type { MatchLike, Player } from '@fulbito/types'
+
+export function defaultGoalkeeping(skill: number | null | undefined): number {
+  return Math.round(skill ?? 5)
+}
+
+export function getGoalkeeping(player: Pick<Player, 'goalkeeping' | 'skill'>): number {
+  return player.goalkeeping ?? defaultGoalkeeping(player.skill)
+}
 
 function relevantSorted(matches: MatchLike[], playerId: string) {
   return matches


### PR DESCRIPTION
## Resumen
- Agrega un **nivel de arquero** (`goalkeeping`) a los jugadores, con valor por defecto = promedio redondeado del jugador y editable en web y mobile.
- Permite marcar **hasta 2 arqueros** al armar/registrar un partido y los persiste en el `Match` (`goalkeeperIds`).
- El balanceo de equipos usa el **nivel de arquero** para los designados y los siembra en equipos distintos.

## Detalle

### Jugadores
- `Player.goalkeeping?: number` + helpers `getGoalkeeping`/`defaultGoalkeeping` en `@fulbito/utils`.
- Persistencia en firebase pkg, store web y mappers mobile.
- Edición en form completo + edición rápida (web) y form mobile (default sigue al promedio hasta editarlo).
- Visualización: `PlayerCard` (web) y barras de habilidad (mobile).

### Partidos
- `Match.goalkeeperIds?: string[]` persistido en web (`useMatchStore`) y mobile (`use-matches-data`).
- Selector de arqueros (máx 2) en `/match` (web), registro de partido (web) y `MatchForm` (mobile).
- Balanceo por nivel de arquero + seedeo uno por equipo.
- 🧤 en armadores de equipo e historial (web + mobile).

<img width="898" height="593" alt="Captura de pantalla 2026-06-04 a la(s) 2 37 21 p  m" src="https://github.com/user-attachments/assets/6e60fccd-7de4-40c7-82e9-508634e02611" />

<img width="1222" height="408" alt="Captura de pantalla 2026-06-04 a la(s) 2 37 37 p  m" src="https://github.com/user-attachments/assets/d28f6f99-6710-4cfc-b653-aed23477c093" />

<img width="531" height="467" alt="Captura de pantalla 2026-06-04 a la(s) 2 38 03 p  m" src="https://github.com/user-attachments/assets/435250e4-223a-4657-8a9e-966d3af044fc" />

<img width="368" height="687" alt="Captura de pantalla 2026-06-04 a la(s) 2 38 46 p  m" src="https://github.com/user-attachments/assets/50bf4e41-bf29-433c-8e91-4526318ba5a4" />

