### PR TITLE
Feat/splash-screen

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -35,9 +35,9 @@
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#7C3AED",
           "dark": {
-            "backgroundColor": "#000000"
+            "backgroundColor": "#7C3AED"
           }
         }
       ],

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,16 +1,20 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native'
 import { Stack, useRouter, useSegments } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import 'react-native-reanimated'
 import { useFonts } from 'expo-font'
+import * as SplashScreen from 'expo-splash-screen'
 
 import { useColorScheme } from '@/hooks/use-color-scheme'
 import { FirebaseAuthProvider, useFirebaseAuth } from '@/contexts/FirebaseAuthContext'
+import AnimatedSplash from '@/components/AnimatedSplash'
 
 export const unstable_settings = {
   anchor: '(tabs)',
 }
+
+SplashScreen.preventAutoHideAsync()
 
 function AuthGuard() {
   const { user, loading } = useFirebaseAuth()
@@ -28,6 +32,27 @@ function AuthGuard() {
   }, [user, loading, segments, router])
 
   return null
+}
+
+const MIN_VISIBLE_MS = 1600
+
+function SplashGate() {
+  const { loading } = useFirebaseAuth()
+  const [visible, setVisible] = useState(true)
+  const [minElapsed, setMinElapsed] = useState(false)
+
+  useEffect(() => {
+    if (!loading) SplashScreen.hideAsync()
+  }, [loading])
+
+  useEffect(() => {
+    const timer = setTimeout(() => setMinElapsed(true), MIN_VISIBLE_MS)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (!visible) return null
+
+  return <AnimatedSplash ready={!loading && minElapsed} onFinish={() => setVisible(false)} />
 }
 
 export default function RootLayout() {
@@ -56,6 +81,7 @@ export default function RootLayout() {
           <Stack.Screen name="login" options={{ headerShown: false }} />
         </Stack>
         <StatusBar style="auto" />
+        <SplashGate />
       </ThemeProvider>
     </FirebaseAuthProvider>
   )

--- a/apps/mobile/components/AnimatedSplash.styles.ts
+++ b/apps/mobile/components/AnimatedSplash.styles.ts
@@ -1,0 +1,26 @@
+import { StyleSheet } from 'react-native'
+
+import { Fonts, Radii, Spacing } from '@/constants/theme'
+
+export const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 999,
+    elevation: 999,
+  },
+  wordmark: {
+    fontFamily: Fonts.black,
+    fontSize: 44,
+    letterSpacing: 0.5,
+    color: '#ffffff',
+  },
+  underline: {
+    height: 4,
+    width: 64,
+    marginTop: Spacing.md,
+    borderRadius: Radii.pill,
+    backgroundColor: '#ffffff',
+  },
+})

--- a/apps/mobile/components/AnimatedSplash.tsx
+++ b/apps/mobile/components/AnimatedSplash.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+import { View } from 'react-native'
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated'
+import { scheduleOnRN } from 'react-native-worklets'
+import { useAppTheme } from '@/hooks/use-theme'
+import { styles } from './AnimatedSplash.styles'
+
+type AnimatedSplashProps = {
+  ready: boolean
+  onFinish: () => void
+}
+
+export default function AnimatedSplash({ ready, onFinish }: AnimatedSplashProps) {
+  const theme = useAppTheme()
+  const containerOpacity = useSharedValue(1)
+  const wordmarkOpacity = useSharedValue(0)
+  const wordmarkScale = useSharedValue(0.85)
+  const underlineWidth = useSharedValue(0)
+
+  useEffect(() => {
+    wordmarkOpacity.value = withTiming(1, { duration: 500 })
+    wordmarkScale.value = withSpring(1, { damping: 13, stiffness: 120 })
+    underlineWidth.value = withDelay(250, withTiming(1, { duration: 450 }))
+  }, [underlineWidth, wordmarkOpacity, wordmarkScale])
+
+  useEffect(() => {
+    if (!ready) return
+    containerOpacity.value = withTiming(0, { duration: 400 }, finished => {
+      if (finished) scheduleOnRN(onFinish)
+    })
+  }, [ready, containerOpacity, onFinish])
+
+  const containerStyle = useAnimatedStyle(() => ({ opacity: containerOpacity.value }))
+  const wordmarkStyle = useAnimatedStyle(() => ({
+    opacity: wordmarkOpacity.value,
+    transform: [{ scale: wordmarkScale.value }],
+  }))
+  const underlineStyle = useAnimatedStyle(() => ({ transform: [{ scaleX: underlineWidth.value }] }))
+
+  return (
+    <Animated.View
+      style={[styles.container, { backgroundColor: theme.colors.brand }, containerStyle]}
+      pointerEvents="none"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel="Cargando FulbitoApp"
+    >
+      <View accessible accessibilityRole="header">
+        <Animated.Text style={[styles.wordmark, wordmarkStyle]}>FulbitoApp</Animated.Text>
+      </View>
+      <Animated.View style={[styles.underline, underlineStyle]} />
+    </Animated.View>
+  )
+}


### PR DESCRIPTION
## Overview
Replaces the static splash with a branded animated transition. On launch, Expo's native splash performs an invisible handoff to an animated layer (AnimatedSplash) that presents the FulbitoApp wordmark with an entrance animation, then fades oout, all while Firebase resolves the auth session.
<img width="808" height="1752" alt="image" src="https://github.com/user-attachments/assets/02ecb5b0-65a7-4a64-bd16-2580762969ad" />
