### PR TITLE
feat(mobile): mobile mvp

### DIFF
--- a/apps/mobile/components/history/matchCard.tsx
+++ b/apps/mobile/components/history/matchCard.tsx
@@ -62,6 +62,7 @@ export function MatchCard({ match: m, players, isAdmin, onEdit, onDelete }: Prop
           winner={winA}
           loser={winB}
           goalkeeperIds={m.goalkeeperIds}
+          mvpId={m.mvpId}
           colors={colors}
           radii={radii}
           spacing={spacing}
@@ -72,6 +73,7 @@ export function MatchCard({ match: m, players, isAdmin, onEdit, onDelete }: Prop
           winner={winB}
           loser={winA}
           goalkeeperIds={m.goalkeeperIds}
+          mvpId={m.mvpId}
           colors={colors}
           radii={radii}
           spacing={spacing}
@@ -111,6 +113,7 @@ function TeamColumn({
   winner,
   loser,
   goalkeeperIds,
+  mvpId,
   colors,
   radii,
   spacing,
@@ -120,6 +123,7 @@ function TeamColumn({
   winner: boolean
   loser: boolean
   goalkeeperIds?: string[]
+  mvpId?: string | null
   colors: TeamColumnColors
   radii: TeamColumnRadii
   spacing: TeamColumnSpacing
@@ -131,10 +135,10 @@ function TeamColumn({
       {players.map((p) => (
         <View key={p.id} style={styles.playerRow}>
           <Text style={[styles.playerName, { color: colors.text }]} numberOfLines={1}>
-            {goalkeeperIds?.includes(p.id) ? '🧤 ' : ''}{p.name}
+            {p.name}
           </Text>
           <Text style={[styles.playerStats, { color: colors.muted }]}>
-            {p.goals}⚽ {p.performance}★
+            {goalkeeperIds?.includes(p.id) ? '🧤 ' : ''}{mvpId === p.id ? '🏆 ' : ''}{p.goals}⚽ {p.performance}★
           </Text>
         </View>
       ))}

--- a/apps/mobile/components/match/matchForm.tsx
+++ b/apps/mobile/components/match/matchForm.tsx
@@ -1,6 +1,6 @@
 import type { Match, Player } from '@fulbito/types'
 import { balanceRemainingPlayers, getGoalkeeping } from '@fulbito/utils'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Alert, ScrollView, StyleSheet, View } from 'react-native'
 
 import { useAppTheme } from '@/hooks/use-theme'
@@ -10,6 +10,7 @@ import { DateField } from './matchForm/dateField'
 import { FormActions } from './matchForm/formActions'
 import { GoalkeeperSection } from './matchForm/goalkeeperSection'
 import { buildMatchPayload, computeTeamStats, toPlayerInfo } from './matchForm/helpers'
+import { MvpSection } from './matchForm/mvpSection'
 import { NameField } from './matchForm/nameField'
 import { PoolSection } from './matchForm/poolSection'
 import { ShirtsSection } from './matchForm/shirtsSection'
@@ -56,6 +57,7 @@ export function MatchForm({
   const [goalkeeperIds, setGoalkeeperIds] = useState<Set<string>>(
     () => new Set(initial?.goalkeeperIds ?? []),
   )
+  const [mvpId, setMvpId] = useState<string | null>(initial?.mvpId ?? null)
 
   // ── State hooks ─────────────────────────────────────────────────────────────
   const pool = usePool(players, initial)
@@ -78,6 +80,13 @@ export function MatchForm({
     scores.teamBScore !== '' &&
     scoreA === scores.totalGoalsA &&
     scoreB === scores.totalGoalsB
+
+  // Si el MVP elegido deja de estar en los equipos, lo limpiamos
+  useEffect(() => {
+    if (!mvpId) return
+    const inTeams = [...teams.teamA, ...teams.teamB].some((p) => p.id === mvpId)
+    if (!inTeams) setMvpId(null)
+  }, [teams.teamA, teams.teamB, mvpId])
 
   // ── Handlers ────────────────────────────────────────────────────────────────
   const handlePoolChange = (ids: Set<string>) => {
@@ -152,6 +161,7 @@ export function MatchForm({
         perfB: scores.perfB,
         shirtsResponsibleId: pickShirtsResponsible(shirts.shirtsResponsibleId, shirts.dutyPoolIds),
         goalkeeperIds: [...goalkeeperIds],
+        mvpId,
       })
       await onSave(payload)
     } catch (e) {
@@ -238,6 +248,17 @@ export function MatchForm({
           onPerfChange={scores.setPerfB}
         />
       </View>
+
+      <MvpSection
+        teamA={teams.teamA}
+        teamB={teams.teamB}
+        mvpId={mvpId}
+        onChange={setMvpId}
+        goalsA={scores.goalsA}
+        goalsB={scores.goalsB}
+        perfA={scores.perfA}
+        perfB={scores.perfB}
+      />
 
       <ShirtsSection
         players={players}

--- a/apps/mobile/components/match/matchForm/helpers.ts
+++ b/apps/mobile/components/match/matchForm/helpers.ts
@@ -67,6 +67,7 @@ export type BuildPayloadInput = {
   perfB: Record<string, string>
   shirtsResponsibleId: string | null
   goalkeeperIds?: string[]
+  mvpId?: string | null
 }
 
 export function buildMatchPayload(input: BuildPayloadInput): Omit<Match, 'id'> {
@@ -92,5 +93,6 @@ export function buildMatchPayload(input: BuildPayloadInput): Omit<Match, 'id'> {
     teamB: buildTeamPlayers(input.teamB, input.goalsB, input.perfB),
     shirtsResponsibleId: input.shirtsResponsibleId,
     goalkeeperIds: input.goalkeeperIds ?? [],
+    mvpId: input.mvpId ?? null,
   }
 }

--- a/apps/mobile/components/match/matchForm/mvpSection.tsx
+++ b/apps/mobile/components/match/matchForm/mvpSection.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import { ScrollView, Text, TouchableOpacity } from 'react-native'
+
+import { useAppTheme } from '@/hooks/use-theme'
+
+import { BottomSheet } from './bottomSheet'
+import { FormLabel } from './formLabel'
+import { fieldStyles, sheetStyles } from './sharedStyles'
+import type { RecordingPlayer } from './types'
+
+type Props = {
+  teamA: RecordingPlayer[]
+  teamB: RecordingPlayer[]
+  mvpId: string | null
+  onChange: (id: string | null) => void
+  goalsA: Record<string, string>
+  goalsB: Record<string, string>
+  perfA: Record<string, string>
+  perfB: Record<string, string>
+}
+
+export function MvpSection({ teamA, teamB, mvpId, onChange, goalsA, goalsB, perfA, perfB }: Props) {
+  const { colors, radii } = useAppTheme()
+  const [open, setOpen] = useState(false)
+
+  const current = [...teamA, ...teamB]
+  const empty = current.length === 0
+
+  const statsFor = (id: string) => ({
+    goals: parseInt(goalsA[id] ?? goalsB[id] ?? '0') || 0,
+    perf: parseFloat(perfA[id] ?? perfB[id] ?? '0') || 0,
+  })
+
+  // Sugerencia: jugador con mejor rendimiento del partido
+  const suggestedId = current.reduce<{ id: string; perf: number } | null>((best, p) => {
+    const { perf } = statsFor(p.id)
+    if (perf > 0 && (!best || perf > best.perf)) return { id: p.id, perf }
+    return best
+  }, null)?.id
+
+  const mvpName = mvpId ? (current.find((p) => p.id === mvpId)?.name ?? '—') : 'Sin MVP'
+
+  return (
+    <>
+      <FormLabel text="MVP del partido" />
+      <TouchableOpacity
+        onPress={() => setOpen(true)}
+        disabled={empty}
+        accessibilityRole="button"
+        accessibilityLabel="Elegir MVP del partido"
+        style={[
+          fieldStyles.inputBtn,
+          { borderColor: colors.border, borderRadius: radii.sm, opacity: empty ? 0.5 : 1 },
+        ]}
+      >
+        <Text style={[fieldStyles.inputBtnText, { color: colors.text }]}>
+          🏆 {empty ? 'Armá los equipos primero' : mvpName}
+        </Text>
+      </TouchableOpacity>
+
+      <BottomSheet visible={open} title="MVP del partido" closeLabel="Listo" onConfirm={() => setOpen(false)}>
+        <ScrollView style={{ maxHeight: 320 }}>
+          <TouchableOpacity
+            onPress={() => {
+              onChange(null)
+              setOpen(false)
+            }}
+            style={[
+              sheetStyles.option,
+              { borderBottomColor: colors.border },
+              mvpId === null && { backgroundColor: colors.brandSoft },
+            ]}
+          >
+            <Text style={[sheetStyles.optionText, { color: colors.text }]}>Sin MVP</Text>
+          </TouchableOpacity>
+          {current.map((p) => {
+            const { goals, perf } = statsFor(p.id)
+            const suggested = p.id === suggestedId
+            return (
+              <TouchableOpacity
+                key={p.id}
+                onPress={() => {
+                  onChange(p.id)
+                  setOpen(false)
+                }}
+                style={[
+                  sheetStyles.option,
+                  { borderBottomColor: colors.border },
+                  mvpId === p.id && { backgroundColor: colors.brandSoft },
+                ]}
+              >
+                <Text style={[sheetStyles.optionText, { color: colors.text }]}>
+                  {p.name}
+                  {suggested ? ' · sugerido' : ''}
+                </Text>
+                <Text style={[sheetStyles.optionText, { color: colors.muted }]}>
+                  ⚽ {goals} · ★ {perf}
+                </Text>
+              </TouchableOpacity>
+            )
+          })}
+        </ScrollView>
+      </BottomSheet>
+    </>
+  )
+}

--- a/apps/mobile/components/players/detail/player-stats-grid.tsx
+++ b/apps/mobile/components/players/detail/player-stats-grid.tsx
@@ -58,6 +58,7 @@ export function PlayerStatsGrid({ stats }: Props) {
         value={stats.avgPerformance.toFixed(1)}
         sub={`W${stats.wins} D${stats.draws} L${stats.losses}`}
       />
+      <StatBox label="MVP" value={String(stats.mvps)} sub="🏆" accent="#f59e0b" />
     </View>
   )
 }

--- a/apps/mobile/components/statistics/stat-filter-tabs.tsx
+++ b/apps/mobile/components/statistics/stat-filter-tabs.tsx
@@ -15,6 +15,7 @@ const TABS: { key: SortTabKey; label: string }[] = [
   { key: 'matches', label: 'Partidos' },
   { key: 'totalPerformance', label: 'Rendimiento' },
   { key: 'winRate', label: '% Victorias' },
+  { key: 'mvps', label: 'MVP' },
 ]
 
 export function StatFilterTabs({ activeTab, onChange }: Props) {

--- a/apps/mobile/components/statistics/stat-player-card.tsx
+++ b/apps/mobile/components/statistics/stat-player-card.tsx
@@ -28,6 +28,8 @@ function getFeaturedValue(stat: PlayerStatRow, activeTab: SortTabKey): { value: 
         value: `${((stat.wins / Math.max(stat.matches, 1)) * 100).toFixed(1)}%`,
         label: 'VICTORIAS',
       }
+    case 'mvps':
+      return { value: `${stat.mvps}`, label: 'MVP' }
     case 'goals':
     default:
       return { value: `${stat.goals}`, label: 'GOLES' }
@@ -117,6 +119,12 @@ export function StatPlayerCard({ stat, rank, activeTab, onPress }: Props) {
             {((stat.wins / Math.max(stat.matches, 1)) * 100).toFixed(1)}%
           </ThemedText>
           <ThemedText style={[styles.metricLabel, { color: colors.muted }]}>VICTORIAS</ThemedText>
+        </View>
+        <View style={styles.metricItem}>
+          <ThemedText type="defaultSemiBold" style={styles.metricValue}>
+            {stat.mvps}
+          </ThemedText>
+          <ThemedText style={[styles.metricLabel, { color: colors.muted }]}>🏆 MVP</ThemedText>
         </View>
       </View>
     </Pressable>

--- a/apps/mobile/hooks/use-player-detail.ts
+++ b/apps/mobile/hooks/use-player-detail.ts
@@ -24,6 +24,7 @@ export type PlayerDetailStats = {
   avgPerformance: number
   gpm: string
   winRate: string
+  mvps: number
   recent: RecentMatchEntry[]
 }
 
@@ -45,6 +46,7 @@ function computeStats(matches: Match[], playerId: string): PlayerDetailStats {
     avgPerformance: 0,
     gpm: '0.0',
     winRate: '0.0',
+    mvps: 0,
     recent: [],
   }
 
@@ -61,6 +63,7 @@ function computeStats(matches: Match[], playerId: string): PlayerDetailStats {
     res.matches++
     res.goals += me.goals
     totalPerformance += me.performance
+    if (m.mvpId === playerId) res.mvps++
 
     let result: 'W' | 'L' | 'D'
     if (a === b) {

--- a/apps/mobile/hooks/use-player-statistics.ts
+++ b/apps/mobile/hooks/use-player-statistics.ts
@@ -1,8 +1,8 @@
 import type { Match, Player } from '@fulbito/types'
-import { getShirtDutiesByPlayerId } from '@fulbito/utils'
+import { getMvpCountsByPlayerId, getShirtDutiesByPlayerId } from '@fulbito/utils'
 import { useMemo, useState } from 'react'
 
-export type SortTabKey = 'goals' | 'matches' | 'totalPerformance' | 'winRate'
+export type SortTabKey = 'goals' | 'matches' | 'totalPerformance' | 'winRate' | 'mvps'
 
 export type PlayerStatRow = {
   id: string
@@ -15,6 +15,7 @@ export type PlayerStatRow = {
   losses: number
   draws: number
   shirts: number
+  mvps: number
 }
 
 export function usePlayerStatistics(players: Player[], matches: Match[]) {
@@ -23,6 +24,7 @@ export function usePlayerStatistics(players: Player[], matches: Match[]) {
   const stats = useMemo<PlayerStatRow[]>(() => {
     const map: Record<string, PlayerStatRow> = {}
     const shirtCountById = getShirtDutiesByPlayerId(matches)
+    const mvpCountById = getMvpCountsByPlayerId(matches)
     const photoById = new Map(players.map((p) => [p.id, p.photoUrl ?? undefined]))
 
     for (const m of matches) {
@@ -46,6 +48,7 @@ export function usePlayerStatistics(players: Player[], matches: Match[]) {
               losses: 0,
               draws: 0,
               shirts: shirtCountById.get(p.id) ?? 0,
+              mvps: mvpCountById.get(p.id) ?? 0,
             }
           }
 
@@ -86,6 +89,8 @@ export function usePlayerStatistics(players: Player[], matches: Match[]) {
           return row.totalPerformance
         case 'winRate':
           return row.matches === 0 ? 0 : row.wins / row.matches
+        case 'mvps':
+          return row.mvps
         case 'goals':
         default:
           return row.goals


### PR DESCRIPTION
## Overview

Brings the **Match MVP** ("jugador del partido") feature to the **mobile** app,
reaching parity with the existing web implementation. The Firestore data layer in
mobile already read/wrote `mvpId`, but it was missing from the match payload and had
no UI. This PR adds the selection flow and the read-side displays.

No new dependencies are introduced, and the tally logic is reused from the shared
`@fulbito/utils` package (`getMvpCountsByPlayerId`) — no duplicated business logic.

## Changes

### MVP selection (match form)
- **New** `MvpSection` (`matchForm/mvpSection.tsx`): a single-select bottom-sheet
  picker, mirroring the existing `ShirtsSection` pattern. It lists players from both
  teams with their goals ⚽ and performance ★, flags the top performer as "· sugerido",
  and offers a "Sin MVP" option.
- `buildMatchPayload` now persists `mvpId` (`matchForm/helpers.ts`).
- `matchForm.tsx`: adds `mvpId` state and an effect that clears it when the selected
  player is no longer in either team (matching web behavior).

### Displays
- **Match history** (`matchCard.tsx`): 🏆 badge rendered next to the MVP's stats,
  matching the web layout (icons on the right, before `goals⚽ performance★`).
- **Player profile** (`player-stats-grid.tsx`, `use-player-detail.ts`): new "MVP" stat
  box showing how many times the player was MVP.
- **Statistics / leaderboard** (`use-player-statistics.ts`, `stat-filter-tabs.tsx`,
  `stat-player-card.tsx`): new "MVP" sort tab, MVP-based ordering, featured value, and
  a 🏆 metric on each card.

## Scope
- Mobile only — no changes to `packages/*` or to the web app.
- `mvpId` Firestore read/write already existed in `use-matches-data.ts`.

## Screenshots

| MVP picker (match form) | History badge | Player profile | Statistics tab |
| --- | --- | --- | --- |
| _drop image here_ | _drop image here_ | _drop image here_ | _drop image here_ |

## Test plan
- [ ] Create/edit a match and select a player in the "MVP del partido" picker.
- [ ] Confirm the 🏆 badge appears next to that player's stats in match history.
- [ ] Open the player's profile and verify the "MVP" stat box count.
- [ ] On Statistics, use the "MVP" tab and confirm ordering and the per-card metric.

## Validation
- `eslint` passes on all changed files.
- `tsc --noEmit` introduces no new type errors (3 pre-existing `warning`/`ThemeColors`
  errors are unrelated to this change).